### PR TITLE
obligation needs also the attributes.

### DIFF
--- a/src/main/java/org/glite/authz/common/model/util/XACMLConverter.java
+++ b/src/main/java/org/glite/authz/common/model/util/XACMLConverter.java
@@ -52,6 +52,7 @@ import org.opensaml.xacml.policy.EffectType;
 import org.opensaml.xacml.policy.ObligationType;
 import org.opensaml.xacml.policy.ObligationsType;
 import org.opensaml.xml.XMLObjectBuilder;
+import java.util.List;
 
 /**
  * A helper class for converting to/from XACML objects.
@@ -324,6 +325,7 @@ public class XACMLConverter {
         }
 
         Obligation obligation = new Obligation();
+	List<AttributeAssignment> obligationAttributeAssignments = obligation.getAttributeAssignments();
 
         AttributeAssignment attributeAssignment;
         if (xacmlObligation.getAttributeAssignments() != null) {
@@ -333,6 +335,8 @@ public class XACMLConverter {
                         .getAttributeId()));
                 attributeAssignment.setDataType(Strings.safeTrimOrNullString(xacmlAttributeAssignment.getDataType()));
                 attributeAssignment.setValue(Strings.safeTrimOrNullString(xacmlAttributeAssignment.getValue()));
+		// Add attributeAssignments to obligation
+		obligationAttributeAssignments.add(attributeAssignment);
             }
         }
 


### PR DESCRIPTION
When copying the XACML obligation into a simple obligation the attributes were
not copied along with the rest.
