### PR TITLE
Fix improper synchronization on the Gridmapdir

### DIFF
--- a/src/main/java/org/glite/authz/pep/obligation/dfpmap/DFPMObligationHandler.java
+++ b/src/main/java/org/glite/authz/pep/obligation/dfpmap/DFPMObligationHandler.java
@@ -35,24 +35,24 @@ import org.glite.authz.common.model.Subject;
 import org.glite.authz.common.profile.GLiteAuthorizationProfileConstants;
 import org.glite.authz.pep.obligation.AbstractObligationHandler;
 import org.glite.authz.pep.obligation.ObligationProcessingException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * An obligation handler that transforms an
- * {@value GLiteAuthorizationProfileConstants#ID_OBLIGATION_LOCAL_ENV_MAP} obligation
- * in to a {@value GLiteAuthorizationProfileConstants#ID_OBLIGATION_POSIX_ENV_MAP}
+ * {@value GLiteAuthorizationProfileConstants#ID_OBLIGATION_LOCAL_ENV_MAP}
+ * obligation in to a
+ * {@value GLiteAuthorizationProfileConstants#ID_OBLIGATION_POSIX_ENV_MAP}
  * obligation. The POSIX login name and primary and secondary group values are
  * determined by mapping the {@value Attribute#ID_SUB_ID},
  * {@value GLiteAuthorizationProfileConstants#ID_ATTRIBUTE_PRIMARY_FQAN} and
- * {@value GLiteAuthorizationProfileConstants#ID_ATTRIBUTE_FQAN} attributes found
- * within the {@link Subject} of the authorization request.
+ * {@value GLiteAuthorizationProfileConstants#ID_ATTRIBUTE_FQAN} attributes
+ * found within the {@link Subject} of the authorization request.
  */
 public class DFPMObligationHandler extends AbstractObligationHandler {
 
     /** Class logger. */
-    private final Logger log= LoggerFactory.getLogger(DFPMObligationHandler.class);
+    private final Logger log = LoggerFactory.getLogger(DFPMObligationHandler.class);
 
     /** DN/FQAN to POSIX account mapper. */
     private AccountMapper accountMapper;
@@ -61,7 +61,7 @@ public class DFPMObligationHandler extends AbstractObligationHandler {
      * Request subject must contain a key-info attribute for this OH to apply:
      * Default {@value}
      */
-    private boolean requireSubjectKeyInfo= true;
+    private boolean requireSubjectKeyInfo = true;
 
     /**
      * Constructor.
@@ -73,14 +73,13 @@ public class DFPMObligationHandler extends AbstractObligationHandler {
      * @param mapper
      *            used to map a subject to a POSIX account
      */
-    public DFPMObligationHandler(String name, String obligationId,
-            AccountMapper mapper) {
-        super(name, obligationId);
+    public DFPMObligationHandler(final String name, final String obligationId, final AccountMapper mapper) {
+	super(name, obligationId);
 
-        if (mapper == null) {
-            throw new IllegalArgumentException("Account mapper may not be null");
-        }
-        accountMapper= mapper;
+	if (mapper == null) {
+	    throw new IllegalArgumentException("Account mapper may not be null");
+	}
+	accountMapper = mapper;
     }
 
     /**
@@ -92,10 +91,8 @@ public class DFPMObligationHandler extends AbstractObligationHandler {
      * @param mapper
      *            mapper used to map a subject to a POSIX account
      */
-    public DFPMObligationHandler(String name, AccountMapper mapper) {
-        this(name,
-             GLiteAuthorizationProfileConstants.ID_OBLIGATION_LOCAL_ENV_MAP,
-             mapper);
+    public DFPMObligationHandler(final String name, final AccountMapper mapper) {
+	this(name, GLiteAuthorizationProfileConstants.ID_OBLIGATION_LOCAL_ENV_MAP, mapper);
     }
 
     /**
@@ -108,63 +105,54 @@ public class DFPMObligationHandler extends AbstractObligationHandler {
      * @param mapper
      *            mapper used to map a subject to a POSIX account
      */
-    public DFPMObligationHandler(String name, int precedence,
-            AccountMapper mapper) {
-        this(name,
-             GLiteAuthorizationProfileConstants.ID_OBLIGATION_LOCAL_ENV_MAP,
-             mapper);
-        setHanderPrecedence(precedence);
+    public DFPMObligationHandler(final String name, final int precedence, final AccountMapper mapper) {
+	this(name, GLiteAuthorizationProfileConstants.ID_OBLIGATION_LOCAL_ENV_MAP, mapper);
+	setHanderPrecedence(precedence);
     }
 
     /** {@inheritDoc} */
-    public boolean evaluateObligation(Request request, Result result)
-            throws ObligationProcessingException {
-        boolean applied= false;
+    public boolean evaluateObligation(final Request request, final Result result) throws ObligationProcessingException {
+	boolean applied = false;
 
-        Subject subject= getSubject(request);
+	Subject subject = getSubject(request);
 
-        // check for the key-info attribute in the request, if required and not
-        // present, don't apply OH
-        if (requireSubjectKeyInfo && !subjectContainsKeyInfo(subject)) {
-            log.info("{}: Does not apply. Requires a request subject key-info attribute, but none found.",
-                     getId());
-            return false;
-        }
+	// check for the key-info attribute in the request, if required and not
+	// present, don't apply OH
+	if (requireSubjectKeyInfo && !subjectContainsKeyInfo(subject)) {
+	    log.info("{}: Does not apply. Requires a request subject key-info attribute, but none found.", getId());
+	    return false;
+	}
 
-        X500Principal subjectDN= getDN(subject);
-        FQAN primaryFQAN= getPrimaryFQAN(subject);
-        List<FQAN> secondaryFQANs= getSecondaryFQANs(subject);
+	X500Principal subjectDN = getDN(subject);
+	FQAN primaryFQAN = getPrimaryFQAN(subject);
+	List<FQAN> secondaryFQANs = getSecondaryFQANs(subject);
 
-        PosixAccount mappedAccount= accountMapper.mapToAccount(subjectDN,
-                                                               primaryFQAN,
-                                                               secondaryFQANs);
+	PosixAccount mappedAccount = accountMapper.mapToAccount(subjectDN, primaryFQAN, secondaryFQANs);
 
-        if (mappedAccount != null) {
-            addPosixMappingObligation(result, mappedAccount);
-            applied= true;
+	if (mappedAccount != null) {
+	    addPosixMappingObligation(result, mappedAccount);
+	    applied = true;
 
-            // Remove the local environment mapping obligation (even if it
-            // appears multiple times)
-            // since we've handled it and replaced it with the POSIX mapping
-            // obligations
-            Iterator<Obligation> obligationItr= result.getObligations().iterator();
-            Obligation obligation;
-            List<Obligation> removedObligations= new ArrayList<Obligation>();
-            while (obligationItr.hasNext()) {
-                obligation= obligationItr.next();
-                if (getObligationId().equals(obligation.getId())) {
-                    removedObligations.add(obligation);
-                }
-            }
-            result.getObligations().removeAll(removedObligations);
-            log.info("{}: DN: {} pFQAN: {} FQANs: {} mapped to POSIX account: {}",
-                     new Object[] { getId(),
-                                   subjectDN.getName(X500Principal.RFC2253),
-                                   primaryFQAN, secondaryFQANs, mappedAccount });
-        }
-        log.debug("Finished processing DN/FQAN to POSIX account mapping obligation for subject {}",
-                  subjectDN.getName());
-        return applied;
+	    // Remove the local environment mapping obligation (even if it
+	    // appears multiple times)
+	    // since we've handled it and replaced it with the POSIX mapping
+	    // obligations
+	    Iterator<Obligation> obligationItr = result.getObligations().iterator();
+	    Obligation obligation;
+	    List<Obligation> removedObligations = new ArrayList<Obligation>();
+	    while (obligationItr.hasNext()) {
+		obligation = obligationItr.next();
+		if (getObligationId().equals(obligation.getId())) {
+		    removedObligations.add(obligation);
+		}
+	    }
+	    result.getObligations().removeAll(removedObligations);
+	    log.info("{}: DN: {} pFQAN: {} FQANs: {} mapped to POSIX account: {}", new Object[] { getId(),
+		    subjectDN.getName(X500Principal.RFC2253), primaryFQAN, secondaryFQANs, mappedAccount });
+	}
+	log.debug("Finished processing DN/FQAN to POSIX account mapping obligation for subject {}",
+		subjectDN.getName());
+	return applied;
     }
 
     /**
@@ -179,18 +167,16 @@ public class DFPMObligationHandler extends AbstractObligationHandler {
      *             thrown if there is zero or more than one subject in the
      *             request
      */
-    private Subject getSubject(Request request)
-            throws ObligationProcessingException {
-        Set<Subject> subjects= request.getSubjects();
-        if (subjects == null || subjects.isEmpty()) {
-            throw new ObligationProcessingException("Unable to process request, it does not contain a subject");
-        }
-        if (subjects.size() != 1) {
-            log.warn("Request contains '{}' subject, unable to process it",
-                     subjects.size());
-            throw new ObligationProcessingException("Requests contains more than one subject");
-        }
-        return subjects.iterator().next();
+    private Subject getSubject(final Request request) throws ObligationProcessingException {
+	Set<Subject> subjects = request.getSubjects();
+	if (subjects == null || subjects.isEmpty()) {
+	    throw new ObligationProcessingException("Unable to process request, it does not contain a subject");
+	}
+	if (subjects.size() != 1) {
+	    log.warn("Request contains '{}' subject, unable to process it", subjects.size());
+	    throw new ObligationProcessingException("Requests contains more than one subject");
+	}
+	return subjects.iterator().next();
     }
 
     /**
@@ -200,16 +186,16 @@ public class DFPMObligationHandler extends AbstractObligationHandler {
      *            the Subject to check
      * @return <code>true</code> if the subject contains a key-info attribute
      */
-    private boolean subjectContainsKeyInfo(Subject subject) {
-        Set<Attribute> attributes= subject.getAttributes();
-        if (attributes != null) {
-            for (Attribute attribute : attributes) {
-                if (Attribute.ID_SUB_KEY_INFO.equals(attribute.getId())) {
-                    return true;
-                }
-            }
-        }
-        return false;
+    private boolean subjectContainsKeyInfo(final Subject subject) {
+	Set<Attribute> attributes = subject.getAttributes();
+	if (attributes != null) {
+	    for (Attribute attribute : attributes) {
+		if (Attribute.ID_SUB_KEY_INFO.equals(attribute.getId())) {
+		    return true;
+		}
+	    }
+	}
+	return false;
     }
 
     /**
@@ -224,53 +210,49 @@ public class DFPMObligationHandler extends AbstractObligationHandler {
      *             thrown if the given attribute contains no values, is not of
      *             the right data type, or its value is not a valid DN
      */
-    private X500Principal getDN(Subject subject)
-            throws ObligationProcessingException {
-        Attribute dnAttribute= null;
-        for (Attribute attribute : subject.getAttributes()) {
-            if (Attribute.ID_SUB_ID.equals(attribute.getId())
-                    && Attribute.DT_X500_NAME.equals(attribute.getDataType())) {
-                log.debug("Extracted subject attribute from request: {}",
-                          attribute);
-                dnAttribute= attribute;
-                break;
-            }
-        }
-        if (dnAttribute == null) {
-            log.error("Subject of the authorization request did not contain a subject ID attribute {} datatype {}",
-                      Attribute.ID_SUB_ID,
-                      Attribute.DT_X500_NAME);
-            throw new ObligationProcessingException("Invalid request, missing subject attribute: "
-                    + Attribute.ID_SUB_ID
-                    + " datatype: "
-                    + Attribute.DT_X500_NAME);
-        }
+    private X500Principal getDN(final Subject subject) throws ObligationProcessingException {
+	Attribute dnAttribute = null;
+	for (Attribute attribute : subject.getAttributes()) {
+	    if (Attribute.ID_SUB_ID.equals(attribute.getId())
+		    && Attribute.DT_X500_NAME.equals(attribute.getDataType())) {
+		log.debug("Extracted subject attribute from request: {}", attribute);
+		dnAttribute = attribute;
+		break;
+	    }
+	}
+	if (dnAttribute == null) {
+	    log.error("Subject of the authorization request did not contain a subject ID attribute {} datatype {}",
+		    Attribute.ID_SUB_ID, Attribute.DT_X500_NAME);
+	    throw new ObligationProcessingException("Invalid request, missing subject attribute: " + Attribute.ID_SUB_ID
+		    + " datatype: " + Attribute.DT_X500_NAME);
+	}
 
-        Set<?> values= dnAttribute.getValues();
-        if (values == null || values.isEmpty()) {
-            log.error("Subject ID attribute of the authorization request did not contain any values");
-            throw new ObligationProcessingException("Invalid request, subject attribute did not contain any values");
-        }
+	Set<?> values = dnAttribute.getValues();
+	if (values == null || values.isEmpty()) {
+	    log.error("Subject ID attribute of the authorization request did not contain any values");
+	    throw new ObligationProcessingException("Invalid request, subject attribute did not contain any values");
+	}
 
-        if (values.size() > 1) {
-            log.warn("Subject ID attribute contains more than one value, only the first will be used");
-        }
+	if (values.size() > 1) {
+	    log.warn("Subject ID attribute contains more than one value, only the first will be used");
+	}
 
-        try {
-            String subjectDN= values.iterator().next().toString();
-            return new X500Principal(subjectDN);
-        } catch (IllegalArgumentException e) {
-            log.error("Value of the Subject ID attribute of the authorization request was not a valid X.509 DN");
-            throw new ObligationProcessingException("Invalid request, value of the Subject ID attribute was not a valid X.509 DN");
-        }
+	try {
+	    String subjectDN = values.iterator().next().toString();
+	    return new X500Principal(subjectDN);
+	} catch (IllegalArgumentException e) {
+	    log.error("Value of the Subject ID attribute of the authorization request was not a valid X.509 DN");
+	    throw new ObligationProcessingException(
+		    "Invalid request, value of the Subject ID attribute was not a valid X.509 DN");
+	}
     }
 
     /**
      * @param requireSubjectKeyInfo
      *            the requireSubjectKeyInfo to set
      */
-    protected void setRequireSubjectKeyInfo(boolean requireSubjectKeyInfo) {
-        this.requireSubjectKeyInfo= requireSubjectKeyInfo;
+    protected void setRequireSubjectKeyInfo(final boolean requireSubjectKeyInfo) {
+	this.requireSubjectKeyInfo = requireSubjectKeyInfo;
     }
 
     /**
@@ -285,48 +267,46 @@ public class DFPMObligationHandler extends AbstractObligationHandler {
      *             thrown if the given attribute contains no values, is not of
      *             the right data type, or its value is not a valid FQAN
      */
-    private FQAN getPrimaryFQAN(Subject subject)
-            throws ObligationProcessingException {
-        Attribute primaryFQANAttribute= null;
+    private FQAN getPrimaryFQAN(final Subject subject) throws ObligationProcessingException {
+	Attribute primaryFQANAttribute = null;
 
-        for (Attribute attribute : subject.getAttributes()) {
-            if (GLiteAuthorizationProfileConstants.ID_ATTRIBUTE_PRIMARY_FQAN.equals(attribute.getId())) {
-                log.debug("Extracted primary FQAN attribute from request: {}",
-                          attribute);
-                primaryFQANAttribute= attribute;
-                break;
-            }
-        }
+	for (Attribute attribute : subject.getAttributes()) {
+	    if (GLiteAuthorizationProfileConstants.ID_ATTRIBUTE_PRIMARY_FQAN.equals(attribute.getId())) {
+		log.debug("Extracted primary FQAN attribute from request: {}", attribute);
+		primaryFQANAttribute = attribute;
+		break;
+	    }
+	}
 
-        if (primaryFQANAttribute == null) {
-            log.debug("Subject of the authorization request did not contain a subject primary FQAN attribute");
-            return null;
-        }
+	if (primaryFQANAttribute == null) {
+	    log.debug("Subject of the authorization request did not contain a subject primary FQAN attribute");
+	    return null;
+	}
 
-        if (!GLiteAuthorizationProfileConstants.DATATYPE_FQAN.equals(primaryFQANAttribute.getDataType())) {
-            log.error("Subject primary FQAN attribute of the authorization request was of the incorrect data type: {}",
-                      primaryFQANAttribute.getDataType());
-            throw new ObligationProcessingException("Invalid request, subject attribute of invalid data type");
-        }
+	if (!GLiteAuthorizationProfileConstants.DATATYPE_FQAN.equals(primaryFQANAttribute.getDataType())) {
+	    log.error("Subject primary FQAN attribute of the authorization request was of the incorrect data type: {}",
+		    primaryFQANAttribute.getDataType());
+	    throw new ObligationProcessingException("Invalid request, subject attribute of invalid data type");
+	}
 
-        Set<?> values= primaryFQANAttribute.getValues();
-        if (values == null || values.isEmpty()) {
-            log.error("Subject primary FQAN attribute of the authorization request did not contain any values");
-            throw new ObligationProcessingException("Invalid request, subject attribute did not contain any values");
-        }
+	Set<?> values = primaryFQANAttribute.getValues();
+	if (values == null || values.isEmpty()) {
+	    log.error("Subject primary FQAN attribute of the authorization request did not contain any values");
+	    throw new ObligationProcessingException("Invalid request, subject attribute did not contain any values");
+	}
 
-        if (values.size() > 1) {
-            log.warn("Primary FQAN attribute contains more than one value, only the first will be used");
-        }
+	if (values.size() > 1) {
+	    log.warn("Primary FQAN attribute contains more than one value, only the first will be used");
+	}
 
-        try {
-            return FQAN.parseFQAN(values.iterator().next().toString());
-        } catch (ParseException e) {
-            log.error("Value of the Subject primary FQAN attribute of the authorization request was not a valid FQAN",
-                      e);
-            throw new ObligationProcessingException("Invalid request, subject's primary FQAN attribute value was invalid",
-                                                    e);
-        }
+	try {
+	    return FQAN.parseFQAN(values.iterator().next().toString());
+	} catch (ParseException e) {
+	    log.error("Value of the Subject primary FQAN attribute of the authorization request was not a valid FQAN",
+		    e);
+	    throw new ObligationProcessingException(
+		    "Invalid request, subject's primary FQAN attribute value was invalid", e);
+	}
     }
 
     /**
@@ -341,108 +321,107 @@ public class DFPMObligationHandler extends AbstractObligationHandler {
      *             thrown if the given attribute contains no values, is not of
      *             the right data type, or its value is not a valid FQAN
      */
-    private List<FQAN> getSecondaryFQANs(Subject subject)
-            throws ObligationProcessingException {
-        Attribute secondaryFQANsAttribute= null;
+    private List<FQAN> getSecondaryFQANs(final Subject subject) throws ObligationProcessingException {
+	Attribute secondaryFQANsAttribute = null;
 
-        for (Attribute attribute : subject.getAttributes()) {
-            if (GLiteAuthorizationProfileConstants.ID_ATTRIBUTE_FQAN.equals(attribute.getId())) {
-                log.debug("Extracted secondary FQAN attribute from request: {}",
-                          attribute);
-                secondaryFQANsAttribute= attribute;
-                break;
-            }
-        }
+	for (Attribute attribute : subject.getAttributes()) {
+	    if (GLiteAuthorizationProfileConstants.ID_ATTRIBUTE_FQAN.equals(attribute.getId())) {
+		log.debug("Extracted secondary FQAN attribute from request: {}", attribute);
+		secondaryFQANsAttribute = attribute;
+		break;
+	    }
+	}
 
-        if (secondaryFQANsAttribute == null) {
-            log.debug("Subject of the authorization request did not contain a subject secondary FQAN attribute");
-            return null;
-        }
+	if (secondaryFQANsAttribute == null) {
+	    log.debug("Subject of the authorization request did not contain a subject secondary FQAN attribute");
+	    return null;
+	}
 
-        if (!GLiteAuthorizationProfileConstants.DATATYPE_FQAN.equals(secondaryFQANsAttribute.getDataType())) {
-            log.error("Subject secondary FQAN attribute of the authorization request was of the incorrect data type: {}",
-                      secondaryFQANsAttribute.getDataType());
-            throw new ObligationProcessingException("Invalid request, subject attribute of invalid data type");
-        }
+	if (!GLiteAuthorizationProfileConstants.DATATYPE_FQAN.equals(secondaryFQANsAttribute.getDataType())) {
+	    log.error(
+		    "Subject secondary FQAN attribute of the authorization request was of the incorrect data type: {}",
+		    secondaryFQANsAttribute.getDataType());
+	    throw new ObligationProcessingException("Invalid request, subject attribute of invalid data type");
+	}
 
-        Set<?> values= secondaryFQANsAttribute.getValues();
-        if (values == null || values.isEmpty()) {
-            log.error("Subject secondary FQAN attribute of the authorization request did not contain any values");
-            throw new ObligationProcessingException("Invalid request, subject attribute did not contain any values");
-        }
+	Set<?> values = secondaryFQANsAttribute.getValues();
+	if (values == null || values.isEmpty()) {
+	    log.error("Subject secondary FQAN attribute of the authorization request did not contain any values");
+	    throw new ObligationProcessingException("Invalid request, subject attribute did not contain any values");
+	}
 
-        List<FQAN> secondaryFQANs= new ArrayList<FQAN>();
-        Iterator<?> valueItr= values.iterator();
-        String value= null;
-        while (valueItr.hasNext()) {
-            try {
-                value= valueItr.next().toString();
-                FQAN parsedFQAN= FQAN.parseFQAN(value);
-                secondaryFQANs.add(parsedFQAN);
-            } catch (ParseException e) {
-                log.error("Subject's secondary FQAN attribute value " + value
-                        + " is not a valid FQAN");
-                throw new ObligationProcessingException("Invalid request, subject's secondary FQAN attribute value was invalid");
-            }
-        }
+	List<FQAN> secondaryFQANs = new ArrayList<FQAN>();
+	Iterator<?> valueItr = values.iterator();
+	String value = null;
+	while (valueItr.hasNext()) {
+	    try {
+		value = valueItr.next().toString();
+		FQAN parsedFQAN = FQAN.parseFQAN(value);
+		secondaryFQANs.add(parsedFQAN);
+	    } catch (ParseException e) {
+		log.error("Subject's secondary FQAN attribute value " + value + " is not a valid FQAN");
+		throw new ObligationProcessingException(
+			"Invalid request, subject's secondary FQAN attribute value was invalid");
+	    }
+	}
 
-        return secondaryFQANs;
+	return secondaryFQANs;
     }
 
     /**
      * 
-     * Adds a 
-     * {@link GLiteAuthorizationProfileConstants#ID_OBLIGATION_POSIX_ENV_MAP} 
-     * to the result.
+     * Adds a
+     * {@link GLiteAuthorizationProfileConstants#ID_OBLIGATION_POSIX_ENV_MAP} to
+     * the result.
      * 
      * @param result
      *            current result
      * @param account
      *            account whose information will be used to populate the
-     *            {@link GLiteAuthorizationProfileConstants#ID_ATTRIBUTE_USER_ID},
+     *            {@link GLiteAuthorizationProfileConstants#ID_ATTRIBUTE_USER_ID}
+     *            ,
      *            {@link GLiteAuthorizationProfileConstants#ID_ATTRIBUTE_PRIMARY_GROUP_ID}
      *            , and
      *            {@link GLiteAuthorizationProfileConstants#ID_ATTRIBUTE_GROUP_ID}
      *            attribute assignments of the obligation
      */
-    protected void addPosixMappingObligation(Result result, PosixAccount account) {
-        Obligation posixMapping= new Obligation();
-        posixMapping.setId(GLiteAuthorizationProfileConstants.ID_OBLIGATION_POSIX_ENV_MAP);
-        posixMapping.setFulfillOn(Result.DECISION_PERMIT);
+    protected void addPosixMappingObligation(final Result result, final PosixAccount account) {
+	Obligation posixMapping = new Obligation();
+	posixMapping.setId(GLiteAuthorizationProfileConstants.ID_OBLIGATION_POSIX_ENV_MAP);
+	posixMapping.setFulfillOn(Result.DECISION_PERMIT);
 
-        AttributeAssignment userid= new AttributeAssignment();
-        userid.setAttributeId(GLiteAuthorizationProfileConstants.ID_ATTRIBUTE_USER_ID);
-        userid.setDataType(Attribute.DT_STRING);
-        userid.setValue(account.getLoginName());
-        posixMapping.getAttributeAssignments().add(userid);
+	AttributeAssignment userid = new AttributeAssignment();
+	userid.setAttributeId(GLiteAuthorizationProfileConstants.ID_ATTRIBUTE_USER_ID);
+	userid.setDataType(Attribute.DT_STRING);
+	userid.setValue(account.getLoginName());
+	posixMapping.getAttributeAssignments().add(userid);
 
-        if (account.getPrimaryGroup() != null) {
-            String groupId= account.getPrimaryGroup();
-            AttributeAssignment primaryGroupId= new AttributeAssignment();
-            primaryGroupId.setAttributeId(GLiteAuthorizationProfileConstants.ID_ATTRIBUTE_PRIMARY_GROUP_ID);
-            primaryGroupId.setDataType(Attribute.DT_STRING);
-            primaryGroupId.setValue(groupId);
-            posixMapping.getAttributeAssignments().add(primaryGroupId);
-            // BUG FIX: profile attribute/group-id doesn't contain primary group
-            // see https://savannah.cern.ch/bugs/index.php?64340
-            AttributeAssignment secondaryGroupId= new AttributeAssignment();
-            secondaryGroupId.setAttributeId(GLiteAuthorizationProfileConstants.ID_ATTRIBUTE_GROUP_ID);
-            secondaryGroupId.setDataType(Attribute.DT_STRING);
-            secondaryGroupId.setValue(groupId);
-            posixMapping.getAttributeAssignments().add(secondaryGroupId);
-        }
+	if (account.getPrimaryGroup() != null) {
+	    String groupId = account.getPrimaryGroup();
+	    AttributeAssignment primaryGroupId = new AttributeAssignment();
+	    primaryGroupId.setAttributeId(GLiteAuthorizationProfileConstants.ID_ATTRIBUTE_PRIMARY_GROUP_ID);
+	    primaryGroupId.setDataType(Attribute.DT_STRING);
+	    primaryGroupId.setValue(groupId);
+	    posixMapping.getAttributeAssignments().add(primaryGroupId);
+	    // BUG FIX: profile attribute/group-id doesn't contain primary group
+	    // see https://savannah.cern.ch/bugs/index.php?64340
+	    AttributeAssignment secondaryGroupId = new AttributeAssignment();
+	    secondaryGroupId.setAttributeId(GLiteAuthorizationProfileConstants.ID_ATTRIBUTE_GROUP_ID);
+	    secondaryGroupId.setDataType(Attribute.DT_STRING);
+	    secondaryGroupId.setValue(groupId);
+	    posixMapping.getAttributeAssignments().add(secondaryGroupId);
+	}
 
-        if (account.getSecondaryGroups() != null
-                && !account.getSecondaryGroups().isEmpty()) {
-            for (String secondaryGroup : account.getSecondaryGroups()) {
-                AttributeAssignment secondaryGroupId= new AttributeAssignment();
-                secondaryGroupId.setAttributeId(GLiteAuthorizationProfileConstants.ID_ATTRIBUTE_GROUP_ID);
-                secondaryGroupId.setDataType(Attribute.DT_STRING);
-                secondaryGroupId.setValue(secondaryGroup);
-                posixMapping.getAttributeAssignments().add(secondaryGroupId);
-            }
-        }
+	if (account.getSecondaryGroups() != null && !account.getSecondaryGroups().isEmpty()) {
+	    for (String secondaryGroup : account.getSecondaryGroups()) {
+		AttributeAssignment secondaryGroupId = new AttributeAssignment();
+		secondaryGroupId.setAttributeId(GLiteAuthorizationProfileConstants.ID_ATTRIBUTE_GROUP_ID);
+		secondaryGroupId.setDataType(Attribute.DT_STRING);
+		secondaryGroupId.setValue(secondaryGroup);
+		posixMapping.getAttributeAssignments().add(secondaryGroupId);
+	    }
+	}
 
-        result.getObligations().add(posixMapping);
+	result.getObligations().add(posixMapping);
     }
 }

--- a/src/main/java/org/glite/authz/pep/obligation/dfpmap/PosixUtil.java
+++ b/src/main/java/org/glite/authz/pep/obligation/dfpmap/PosixUtil.java
@@ -18,17 +18,15 @@
 package org.glite.authz.pep.obligation.dfpmap;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.PrintStream;
 
 import org.jruby.ext.posix.FileStat;
 import org.jruby.ext.posix.POSIX;
+import org.jruby.ext.posix.POSIX.ERRORS;
 import org.jruby.ext.posix.POSIXFactory;
 import org.jruby.ext.posix.POSIXHandler;
-import org.jruby.ext.posix.POSIX.ERRORS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,11 +34,10 @@ import org.slf4j.LoggerFactory;
 public class PosixUtil {
 
     /** POSIX bridge implementation. */
-    private static POSIX posix= POSIXFactory.getPOSIX(new BasicPOSIXHandler(),
-                                                      true);
+    private static POSIX posix = POSIXFactory.getPOSIX(new BasicPOSIXHandler(), true);
 
     /** Class logger. */
-    private static Logger log= LoggerFactory.getLogger(PosixUtil.class);
+    private static Logger log = LoggerFactory.getLogger(PosixUtil.class);
 
     /**
      * Gets the stats about the given file.
@@ -50,8 +47,8 @@ public class PosixUtil {
      * 
      * @return the stats on the file
      */
-    public static FileStat getFileStat(String file) {
-        return posix.stat(file);
+    public static FileStat getFileStat(final String file) {
+	return posix.stat(file);
     }
 
     /**
@@ -66,14 +63,12 @@ public class PosixUtil {
      *            true if the link should be a symbolic or false if it should be
      *            a hard link
      */
-    public static void createLink(String currenPath, String newPath,
-            boolean symbolic) {
-        if (symbolic) {
-            posix.symlink(currenPath, newPath);
-        }
-        else {
-            posix.link(currenPath, newPath);
-        }
+    public static void createLink(final String currenPath, final String newPath, final boolean symbolic) {
+	if (symbolic) {
+	    posix.symlink(currenPath, newPath);
+	} else {
+	    posix.link(currenPath, newPath);
+	}
     }
 
     /**
@@ -84,8 +79,8 @@ public class PosixUtil {
      * @param targetPath
      *            absolute target path
      */
-    public static void createSymlink(String sourcePath, String targetPath) {
-        createLink(sourcePath, targetPath, true);
+    public static void createSymlink(final String sourcePath, final String targetPath) {
+	createLink(sourcePath, targetPath, true);
     }
 
     /**
@@ -96,8 +91,8 @@ public class PosixUtil {
      * @param targetPath
      *            absolute target path
      */
-    public static void createHardlink(String sourcePath, String targetPath) {
-        createLink(sourcePath, targetPath, false);
+    public static void createHardlink(final String sourcePath, final String targetPath) {
+	createLink(sourcePath, targetPath, false);
     }
 
     /**
@@ -107,87 +102,74 @@ public class PosixUtil {
      * @param file
      *            the file to "touch"
      */
-    public static void touchFile(File file) {
-        try {
-            log.debug("touch {}", file.getAbsolutePath());
-            if (!file.exists()) {
-                OutputStream out= new FileOutputStream(file);
-                out.close();
-            }
-            boolean success= file.setLastModified(System.currentTimeMillis());
-            if (!success) {
-                throw new IOException("Unable to set the last modification time for "
-                        + file);
-            }
-        } catch (IOException e) {
-            log.warn("touch {} failed: {}",
-                     file.getAbsolutePath(),
-                     e.getMessage());
-        }
+    public static void touchFile(final File file) {
+	try {
+	    log.debug("touch {}", file.getAbsolutePath());
+	    if (!file.exists()) {
+		file.createNewFile();
+	    }
+	    boolean success = file.setLastModified(System.currentTimeMillis());
+	    if (!success) {
+		throw new IOException("Unable to set the last modification time for " + file);
+	    }
+	} catch (IOException e) {
+	    log.warn("touch {} failed: {}", file.getAbsolutePath(), e.getMessage());
+	}
 
     }
 
     /** A basic handler for logging and stream handling. */
     public static class BasicPOSIXHandler implements POSIXHandler {
 
-        /** {@inheritDoc} */
-        public void error(ERRORS error, String extraData) {
-            log.error("Error performing POSIX operation. Error: "
-                    + error.toString() + ", additional data: " + extraData);
-        }
+	public void error(final ERRORS error, final String extraData) {
+	    log.error(
+		    "Error performing POSIX operation. Error: " + error.toString() + ", additional data: " + extraData);
+	}
 
-        /** {@inheritDoc} */
-        public void unimplementedError(String methodName) {
-            log.error("Error performing POSIX operation.  Operation "
-                    + methodName + " is not supported");
-        }
+	public void unimplementedError(final String methodName) {
+	    log.error("Error performing POSIX operation.  Operation " + methodName + " is not supported");
+	}
 
-        /** {@inheritDoc} */
-        public void warn(WARNING_ID id, String message, Object... data) {
-            log.warn(message);
-        }
+	public void warn(final WARNING_ID id, final String message, final Object... data) {
+	    log.warn(message);
+	}
 
-        /** {@inheritDoc} */
-        public boolean isVerbose() {
-            return false;
-        }
+	public boolean isVerbose() {
+	    return false;
+	}
 
-        /** {@inheritDoc} */
-        public File getCurrentWorkingDirectory() {
-            return new File("/tmp");
-        }
+	public File getCurrentWorkingDirectory() {
+	    return new File("/tmp");
+	}
 
-        /**
-         * {@inheritDoc}
-         * 
-         * This operation is <strong>not</strong> supported.
-         */
-        public String[] getEnv() {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * This operation is <strong>not</strong> supported.
+	 */
+	public String[] getEnv() {
+	    throw new UnsupportedOperationException("Not supported yet.");
+	}
 
-        /** {@inheritDoc} */
-        public InputStream getInputStream() {
-            return System.in;
-        }
+	public InputStream getInputStream() {
+	    return System.in;
+	}
 
-        /** {@inheritDoc} */
-        public PrintStream getOutputStream() {
-            return System.out;
-        }
+	public PrintStream getOutputStream() {
+	    return System.out;
+	}
 
-        /**
-         * {@inheritDoc}
-         * 
-         * This operation is <strong>not</strong> supported.
-         */
-        public int getPID() {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * This operation is <strong>not</strong> supported.
+	 */
+	public int getPID() {
+	    throw new UnsupportedOperationException("Not supported yet.");
+	}
 
-        /** {@inheritDoc} */
-        public PrintStream getErrorStream() {
-            return System.err;
-        }
+	public PrintStream getErrorStream() {
+	    return System.err;
+	}
     }
 }

--- a/src/main/java/org/glite/authz/pep/server/PEPDaemonRequestHandler.java
+++ b/src/main/java/org/glite/authz/pep/server/PEPDaemonRequestHandler.java
@@ -21,11 +21,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
-import net.jcip.annotations.ThreadSafe;
-import net.sf.ehcache.Cache;
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.store.MemoryStoreEvictionPolicy;
-
 import org.glite.authz.common.AuthzServiceConstants;
 import org.glite.authz.common.context.DecisionRequestContext;
 import org.glite.authz.common.context.DecisionRequestContextHelper;
@@ -43,6 +38,7 @@ import org.glite.authz.pep.server.config.PEPDaemonConfiguration;
 import org.opensaml.Configuration;
 import org.opensaml.saml2.core.Assertion;
 import org.opensaml.saml2.core.Statement;
+import org.opensaml.ws.soap.client.SOAPClient;
 import org.opensaml.ws.soap.client.SOAPFaultException;
 import org.opensaml.ws.soap.client.http.HttpSOAPRequestParameters;
 import org.opensaml.ws.soap.common.SOAPException;
@@ -58,21 +54,26 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 
+import net.jcip.annotations.ThreadSafe;
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.store.MemoryStoreEvictionPolicy;
+
 /** Handles an incoming daemon {@link Request}. */
 @ThreadSafe
 public class PEPDaemonRequestHandler {
 
     /** Name of the cache used to cache PDP responses. */
-    public static final String RESPONSE_CACHE_NAME= "org.glite.authz.pep.server.responseCache";
+    public static final String RESPONSE_CACHE_NAME = "org.glite.authz.pep.server.responseCache";
 
     /** Class logger. */
-    private final Logger log= LoggerFactory.getLogger(PEPDaemonRequestHandler.class);
+    private final Logger log = LoggerFactory.getLogger(PEPDaemonRequestHandler.class);
 
     /** Audit log. */
-    private final Logger auditLog= LoggerFactory.getLogger(LoggingConstants.AUDIT_CATEGORY);
+    private final Logger auditLog = LoggerFactory.getLogger(LoggingConstants.AUDIT_CATEGORY);
 
     /** Protocol message log. */
-    private final Logger protocolLog= LoggerFactory.getLogger(LoggingConstants.PROTOCOL_MESSAGE_CATEGORY);
+    private final Logger protocolLog = LoggerFactory.getLogger(LoggingConstants.PROTOCOL_MESSAGE_CATEGORY);
 
     /** The daemon's configuration. */
     private PEPDaemonConfiguration daemonConfig;
@@ -87,19 +88,20 @@ public class PEPDaemonRequestHandler {
      *            the constructor for the daemon
      */
     public PEPDaemonRequestHandler(final PEPDaemonConfiguration config) {
-        if (config == null) {
-            throw new IllegalArgumentException("Daemon configuration may not be null");
-        }
-        daemonConfig= config;
+	if (config == null) {
+	    throw new IllegalArgumentException("Daemon configuration may not be null");
+	}
+	daemonConfig = config;
 
-        if (daemonConfig.getMaxCachedResponses() > 0) {
-            CacheManager cacheMgr= CacheManager.create();
-            responseCache= new Cache(RESPONSE_CACHE_NAME, daemonConfig.getMaxCachedResponses(), MemoryStoreEvictionPolicy.LFU, false, null, false, daemonConfig.getCachedResponseTTL(), daemonConfig.getCachedResponseTTL(), false, Long.MAX_VALUE, null, null);
-            cacheMgr.addCache(responseCache);
-        }
-        else {
-            responseCache= null;
-        }
+	if (daemonConfig.getMaxCachedResponses() > 0) {
+	    CacheManager cacheMgr = CacheManager.create();
+	    responseCache = new Cache(RESPONSE_CACHE_NAME, daemonConfig.getMaxCachedResponses(),
+		    MemoryStoreEvictionPolicy.LFU, false, null, false, daemonConfig.getCachedResponseTTL(),
+		    daemonConfig.getCachedResponseTTL(), false, Long.MAX_VALUE, null, null);
+	    cacheMgr.addCache(responseCache);
+	} else {
+	    responseCache = null;
+	}
     }
 
     /**
@@ -119,88 +121,87 @@ public class PEPDaemonRequestHandler {
      *             thrown if there is an error writing a response to the output
      *             stream
      */
-    public Response handle(Request request) throws IOException {
-        daemonConfig.getServiceMetrics().incrementTotalServiceRequests();
+    public Response handle(final Request request) throws IOException {
+	daemonConfig.getServiceMetrics().incrementTotalServiceRequests();
 
-        PEPDaemonDecisionRequestContext messageContext= buildMessageContext(daemonConfig.getEntityId());
+	PEPDaemonDecisionRequestContext messageContext = buildMessageContext(daemonConfig.getEntityId());
 
-        Response response= null;
-        try {
-            // run the policy information points over the request
-            for (PolicyInformationPoint pip : daemonConfig.getPolicyInformationPoints()) {
-                if (pip.populateRequest(request)) {
-                    log.debug("PIP {} applied to Hessian request", pip.getId());
-                }
-                else {
-                    log.debug("PIP {} do not apply to request", pip.getId());
-                }
-            }
-            protocolLog.info("Hessian request after PIPs have been run\n{}", request.toString());
+	Response response = null;
+	try {
+	    // run the policy information points over the request
+	    for (PolicyInformationPoint pip : daemonConfig.getPolicyInformationPoints()) {
+		if (pip.populateRequest(request)) {
+		    log.debug("PIP {} applied to Hessian request", pip.getId());
+		} else {
+		    log.debug("PIP {} do not apply to request", pip.getId());
+		}
+	    }
+	    protocolLog.info("Hessian request after PIPs have been run\n{}", request.toString());
 
-            // check to see if we have a cached response
-            if (responseCache != null) {
-                log.debug("Checking if a response has already been cached for this request");
-                net.sf.ehcache.Element cacheElement= responseCache.get(request);
-                if (cacheElement != null) {
-                    Response cachedResponse= (Response) cacheElement.getValue();
-                    if (cachedResponse != null) {
-                        log.debug("Cached response found, using it");
-                        response= cachedResponse;
-                    }
-                }
-            }
-            // if no cached response, send request to PDP
-            if (response == null) {
-                log.debug("Response not found in cache, send to PDP");
-                response= sendRequestToPDP(messageContext, request);
-                if (response == null) {
-                    String error= "No response received from PDP: " + daemonConfig.getPDPEndpoints();
-                    log.error(error);
-                    daemonConfig.getServiceMetrics().incrementTotalServiceRequestErrors();
-                    response= buildErrorResponse(request, StatusCodeType.SC_PROCESSING_ERROR, error);
-                    writeAuditLogEntry(messageContext);
-                    return response;
-                }
-            }
+	    // check to see if we have a cached response
+	    if (responseCache != null) {
+		log.debug("Checking if a response has already been cached for this request");
+		net.sf.ehcache.Element cacheElement = responseCache.get(request);
+		if (cacheElement != null) {
+		    Response cachedResponse = (Response) cacheElement.getValue();
+		    if (cachedResponse != null) {
+			log.debug("Cached response found, using it");
+			response = cachedResponse;
+			messageContext.setRespondingPDP("PEPD cache");
+			messageContext.setAuthorizationDecision(response.getResults().get(0).getDecisionString());
+		    }
+		}
+	    }
+	    // if no cached response, send request to PDP
+	    if (response == null) {
+		log.debug("Response not found in cache, send to PDP");
+		response = sendRequestToPDP(messageContext, request);
+		if (response == null) {
+		    String error = "No response received from PDP: " + daemonConfig.getPDPEndpoints();
+		    log.error(error);
+		    daemonConfig.getServiceMetrics().incrementTotalServiceRequestErrors();
+		    response = buildErrorResponse(request, StatusCodeType.SC_PROCESSING_ERROR, error);
+		    writeAuditLogEntry(messageContext);
+		    return response;
+		}
+	    }
 
-            Result result= response.getResults().get(0);
-            // cache Deny/Permit decisions
-            if (responseCache != null
-                    && (result.getDecision() == Result.DECISION_DENY || result.getDecision() == Result.DECISION_PERMIT)) {
-                log.debug("Caching response {} for request {}", messageContext.getInboundMessageId(), messageContext.getOutboundMessageId());
-                responseCache.put(new net.sf.ehcache.Element(request, response));
-            }
+	    Result result = response.getResults().get(0);
+	    // cache Deny/Permit decisions
+	    if (responseCache != null && (result.getDecision() == Result.DECISION_DENY
+		    || result.getDecision() == Result.DECISION_PERMIT)) {
+		log.debug("Caching response {} for request {}", messageContext.getInboundMessageId(),
+			messageContext.getOutboundMessageId());
+		responseCache.put(new net.sf.ehcache.Element(request, response));
+	    }
 
-            // run obligations handlers over the response
-            if (daemonConfig.getObligationService() != null) {
-                log.debug("Processing obligations");
-                daemonConfig.getObligationService().processObligations(request, result);
-            }
+	    // run obligations handlers over the response
+	    if (daemonConfig.getObligationService() != null) {
+		log.debug("Processing obligations");
+		daemonConfig.getObligationService().processObligations(request, result);
+	    }
 
-            
-        } catch (PIPProcessingException e) {
-            daemonConfig.getServiceMetrics().incrementTotalServiceRequestErrors();
-            log.error("Error processing PIP: "
-                    + e.getMessage());
-            log.debug("", e);
-            response= buildErrorResponse(request, StatusCodeType.SC_PROCESSING_ERROR, e.getMessage());
-        } catch (ObligationProcessingException e) {
-            daemonConfig.getServiceMetrics().incrementTotalServiceRequestErrors();
-            log.error("Error processing obligation handlers: " + e.getMessage());
-            log.debug("", e);
-            response= buildErrorResponse(request, StatusCodeType.SC_PROCESSING_ERROR, e.getMessage());
-        } catch (Exception e) {
-            daemonConfig.getServiceMetrics().incrementTotalServiceRequestErrors();
-            log.error("Error processing authorization request: "
-                    + e.getMessage());
-            log.debug("", e);
-            response= buildErrorResponse(request, StatusCodeType.SC_PROCESSING_ERROR, e.getMessage());
-        } finally {
-            protocolLog.info("Complete hessian response\n{}", response.toString());
-        }
+	} catch (PIPProcessingException e) {
+	    daemonConfig.getServiceMetrics().incrementTotalServiceRequestErrors();
+	    log.error("Error processing PIP: " + e.getMessage());
+	    log.debug("", e);
+	    response = buildErrorResponse(request, StatusCodeType.SC_PROCESSING_ERROR, e.getMessage());
+	} catch (ObligationProcessingException e) {
+	    daemonConfig.getServiceMetrics().incrementTotalServiceRequestErrors();
+	    log.error("Error processing obligation handlers: " + e.getMessage());
+	    log.debug("", e);
+	    response = buildErrorResponse(request, StatusCodeType.SC_PROCESSING_ERROR, e.getMessage());
+	} catch (Exception e) {
+	    daemonConfig.getServiceMetrics().incrementTotalServiceRequestErrors();
+	    log.error("Error processing authorization request: " + e.getMessage());
+	    log.debug("", e);
+	    response = buildErrorResponse(request, StatusCodeType.SC_PROCESSING_ERROR, e.getMessage());
+	} finally {
+	    protocolLog.info("Complete hessian response\n{}", response.toString());
+	}
 
-        writeAuditLogEntry(messageContext);
-        return response;
+	writeAuditLogEntry(messageContext);
+	return response;
     }
 
     /**
@@ -216,57 +217,56 @@ public class PEPDaemonRequestHandler {
      * 
      * @return the returned response
      */
-    private Response sendRequestToPDP(PEPDaemonDecisionRequestContext messageContext,
-                                      Request authzRequest) {
-        RequestType xacmlRequest= XACMLConverter.requestToXACML(authzRequest);
-        Envelope soapRequest= DecisionRequestContextHelper.buildSOAPMessage(daemonConfig.getEntityId(), messageContext, xacmlRequest);
-        logSOAPProtocolMessage(soapRequest, true);
+    private Response sendRequestToPDP(final PEPDaemonDecisionRequestContext messageContext,
+	    final Request authzRequest) {
+	RequestType xacmlRequest = XACMLConverter.requestToXACML(authzRequest);
+	Envelope soapRequest = DecisionRequestContextHelper.buildSOAPMessage(daemonConfig.getEntityId(), messageContext,
+		xacmlRequest);
+	logSOAPProtocolMessage(soapRequest, true);
 
-        Iterator<String> pdpItr= daemonConfig.getPDPEndpoints().iterator();
-        String pdpEndpoint= null;
-        Response authzResponse= null;
-        String errorMessage= null;
-        while (pdpItr.hasNext()) {
-            try {
-                pdpEndpoint= pdpItr.next();
-                log.debug("Sending request {} to {}", messageContext.getOutboundMessageId(), pdpEndpoint);
-                daemonConfig.getSOAPClient().send(pdpEndpoint, messageContext);
-                authzResponse= extractResponse(messageContext, pdpEndpoint, (Envelope) messageContext.getInboundMessage());
-                if (authzResponse != null) {
-                    logSOAPProtocolMessage(messageContext.getInboundMessage(), false);
-                    messageContext.setRespondingPDP(pdpEndpoint);
-                    messageContext.setAuthorizationDecision(authzResponse.getResults().get(0).getDecisionString());
-                    break;
-                }
-            } catch (SOAPFaultException e) {
-                String error= "Recieved SOAP Fault " + e.getFault().getCode()
-                        + " from PDP: " + pdpEndpoint;
-                log.warn(error, e);
-                errorMessage= error;
-            } catch (SOAPException e) {
-                String error= "Error sending request to PDP: " + pdpEndpoint;
-                log.error(error, e);
-                errorMessage= error;                
-            } catch (SecurityException e) {
-                String error= "Response from PDP " + pdpEndpoint
-                        + " did not meet message security requirements";
-                log.error(error, e);
-                errorMessage= error;                
-            }
-        }
+	Iterator<String> pdpItr = daemonConfig.getPDPEndpoints().iterator();
+	String pdpEndpoint = null;
+	Response authzResponse = null;
+	String errorMessage = null;
+	while (pdpItr.hasNext()) {
+	    try {
+		pdpEndpoint = pdpItr.next();
+		log.debug("Sending request {} to {}", messageContext.getOutboundMessageId(), pdpEndpoint);
+		SOAPClient lClient = daemonConfig.getSOAPClient();
+		lClient.send(pdpEndpoint, messageContext);
+		authzResponse = extractResponse(messageContext, pdpEndpoint,
+			(Envelope) messageContext.getInboundMessage());
+		if (authzResponse != null) {
+		    logSOAPProtocolMessage(messageContext.getInboundMessage(), false);
+		    messageContext.setRespondingPDP(pdpEndpoint);
+		    messageContext.setAuthorizationDecision(authzResponse.getResults().get(0).getDecisionString());
+		    break;
+		}
+	    } catch (SOAPFaultException e) {
+		String error = "Recieved SOAP Fault " + e.getFault().getCode() + " from PDP: " + pdpEndpoint;
+		log.warn(error, e);
+		errorMessage = error;
+	    } catch (SOAPException e) {
+		String error = "Error sending request to PDP: " + pdpEndpoint;
+		log.error(error, e);
+		errorMessage = error;
+	    } catch (SecurityException e) {
+		String error = "Response from PDP " + pdpEndpoint + " did not meet message security requirements";
+		log.error(error, e);
+		errorMessage = error;
+	    }
+	}
 
-        if (authzResponse != null) {
-            log.debug("A decision of {} was reached by {} in response to request {}", new Object[] {
-                    authzResponse.getResults().get(0).getDecisionString(),
-                    messageContext.getRespondingPDP(),
-                    messageContext.getOutboundMessageId(), });
-            return authzResponse;
-        }
-        else {
-            log.error("No PDP endpoint was able to answer the authorization request");
-            messageContext.setProcessingError(errorMessage);
-            return null;
-        }
+	if (authzResponse != null) {
+	    log.debug("A decision of {} was reached by {} in response to request {}",
+		    new Object[] { authzResponse.getResults().get(0).getDecisionString(),
+			    messageContext.getRespondingPDP(), messageContext.getOutboundMessageId(), });
+	    return authzResponse;
+	} else {
+	    log.error("No PDP endpoint was able to answer the authorization request");
+	    messageContext.setProcessingError(errorMessage);
+	    return null;
+	}
     }
 
     /**
@@ -283,34 +283,37 @@ public class PEPDaemonRequestHandler {
      * 
      * @return the extract response or <code>null</code> on error.
      */
-    private Response extractResponse(DecisionRequestContext messageContext,
-                                     String pdpEndpoint, Envelope soapResponse) {
-        org.opensaml.saml2.core.Response samlResponse= (org.opensaml.saml2.core.Response) soapResponse.getBody().getOrderedChildren().get(0);
+    private Response extractResponse(final DecisionRequestContext messageContext, final String pdpEndpoint,
+	    final Envelope soapResponse) {
+	org.opensaml.saml2.core.Response samlResponse = (org.opensaml.saml2.core.Response) soapResponse.getBody()
+		.getOrderedChildren().get(0);
 
-        if (samlResponse.getAssertions() == null
-                || samlResponse.getAssertions().isEmpty()) {
-            log.warn("Response from PDP {} was an invalid message.  It did not contain an assertion", pdpEndpoint);
-            return null;
-        }
-        if (samlResponse.getAssertions().size() > 1) {
-            log.warn("Response from PDP {} was an invalid message.  It contained more than 1 assertion", pdpEndpoint);
-            return null;
-        }
-        Assertion samlAssertion= samlResponse.getAssertions().get(0);
+	if (samlResponse.getAssertions() == null || samlResponse.getAssertions().isEmpty()) {
+	    log.warn("Response from PDP {} was an invalid message.  It did not contain an assertion", pdpEndpoint);
+	    return null;
+	}
+	if (samlResponse.getAssertions().size() > 1) {
+	    log.warn("Response from PDP {} was an invalid message.  It contained more than 1 assertion", pdpEndpoint);
+	    return null;
+	}
+	Assertion samlAssertion = samlResponse.getAssertions().get(0);
 
-        List<Statement> authzStatements= samlAssertion.getStatements(XACMLAuthzDecisionStatementType.TYPE_NAME_XACML20);
-        if (authzStatements == null || authzStatements.isEmpty()) {
-            log.warn("Response from PDP {} was an invalid message.  It did not contain an authorization statement", pdpEndpoint);
-            return null;
-        }
-        if (authzStatements.size() > 1) {
-            log.warn("Response from PDP {} was an invalid message.  It contained more than 1 authorization statement", pdpEndpoint);
-            return null;
-        }
+	List<Statement> authzStatements = samlAssertion
+		.getStatements(XACMLAuthzDecisionStatementType.TYPE_NAME_XACML20);
+	if (authzStatements == null || authzStatements.isEmpty()) {
+	    log.warn("Response from PDP {} was an invalid message.  It did not contain an authorization statement",
+		    pdpEndpoint);
+	    return null;
+	}
+	if (authzStatements.size() > 1) {
+	    log.warn("Response from PDP {} was an invalid message.  It contained more than 1 authorization statement",
+		    pdpEndpoint);
+	    return null;
+	}
 
-        messageContext.setInboundMessageId(samlResponse.getID());
-        XACMLAuthzDecisionStatementType authzStatement= (XACMLAuthzDecisionStatementType) authzStatements.get(0);
-        return XACMLConverter.responseFromXACML(authzStatement.getResponse(), authzStatement.getRequest());
+	messageContext.setInboundMessageId(samlResponse.getID());
+	XACMLAuthzDecisionStatementType authzStatement = (XACMLAuthzDecisionStatementType) authzStatements.get(0);
+	return XACMLConverter.responseFromXACML(authzStatement.getResponse(), authzStatement.getRequest());
     }
 
     /**
@@ -326,25 +329,24 @@ public class PEPDaemonRequestHandler {
      * 
      * @return the built response
      */
-    private Response buildErrorResponse(Request request, String statusCode,
-                                        String errorMessage) {
-        StatusCode errorCode= new StatusCode();
-        errorCode.setCode(statusCode);
+    private Response buildErrorResponse(final Request request, final String statusCode, final String errorMessage) {
+	StatusCode errorCode = new StatusCode();
+	errorCode.setCode(statusCode);
 
-        Status status= new Status();
-        status.setCode(errorCode);
-        if (errorMessage != null) {
-            status.setMessage(errorMessage);
-        }
+	Status status = new Status();
+	status.setCode(errorCode);
+	if (errorMessage != null) {
+	    status.setMessage(errorMessage);
+	}
 
-        Result result= new Result();
-        result.setDecision(Result.DECISION_INDETERMINATE);
-        result.setStatus(status);
+	Result result = new Result();
+	result.setDecision(Result.DECISION_INDETERMINATE);
+	result.setStatus(status);
 
-        Response response= new Response();
-        response.setRequest(request);
-        response.getResults().add(result);
-        return response;
+	Response response = new Response();
+	response.setRequest(request);
+	response.getResults().add(result);
+	return response;
     }
 
     /**
@@ -355,24 +357,23 @@ public class PEPDaemonRequestHandler {
      * @param isRequest
      *            whether the message is a request
      */
-    private void logSOAPProtocolMessage(XMLObject message, boolean isRequest) {
-        if (message == null) {
-            return;
-        }
+    private void logSOAPProtocolMessage(final XMLObject message, final boolean isRequest) {
+	if (message == null) {
+	    return;
+	}
 
-        if (protocolLog.isDebugEnabled()) {
-            try {
-                Element messageDom= Configuration.getMarshallerFactory().getMarshaller(message).marshall(message);
-                if (isRequest) {
-                    protocolLog.debug("Outgoing SOAP request\n{}", XMLHelper.prettyPrintXML(messageDom));
-                }
-                else {
-                    protocolLog.debug("Inbound SOAP response\n{}", XMLHelper.prettyPrintXML(messageDom));
-                }
-            } catch (MarshallingException e) {
-                log.error("Unable to marshall SOAP message");
-            }
-        }
+	if (protocolLog.isDebugEnabled()) {
+	    try {
+		Element messageDom = Configuration.getMarshallerFactory().getMarshaller(message).marshall(message);
+		if (isRequest) {
+		    protocolLog.debug("Outgoing SOAP request\n{}", XMLHelper.prettyPrintXML(messageDom));
+		} else {
+		    protocolLog.debug("Inbound SOAP response\n{}", XMLHelper.prettyPrintXML(messageDom));
+		}
+	    } catch (MarshallingException e) {
+		log.error("Unable to marshall SOAP message");
+	    }
+	}
     }
 
     /**
@@ -381,10 +382,12 @@ public class PEPDaemonRequestHandler {
      * @param messageContext
      *            current message context
      */
-    private void writeAuditLogEntry(PEPDaemonDecisionRequestContext messageContext) {
-        AuditLogEntry entry= new AuditLogEntry(messageContext.getOutboundMessageId(), messageContext.getRespondingPDP(), messageContext.getInboundMessageId(), messageContext.getAuthorizationDecision());
-        entry.setErrorMessage(messageContext.getProcessingError());
-        auditLog.info(entry.toString());
+    private void writeAuditLogEntry(final PEPDaemonDecisionRequestContext messageContext) {
+	AuditLogEntry entry = new AuditLogEntry(messageContext.getOutboundMessageId(),
+		messageContext.getRespondingPDP(), messageContext.getInboundMessageId(),
+		messageContext.getAuthorizationDecision());
+	entry.setErrorMessage(messageContext.getProcessingError());
+	auditLog.info(entry.toString());
     }
 
     /**
@@ -393,26 +396,25 @@ public class PEPDaemonRequestHandler {
      * 
      * @see PEPDaemonRequestHandler#buildMessageContext(String)
      */
-    protected class PEPDaemonDecisionRequestContext extends
-            DecisionRequestContext {
+    protected class PEPDaemonDecisionRequestContext extends DecisionRequestContext {
 
-        /** The processing error message. */
-        private String processingError_;
+	/** The processing error message. */
+	private String processingError_;
 
-        /**
-         * @return the processing error
-         */
-        public String getProcessingError() {
-            return processingError_;
-        }
+	/**
+	 * @return the processing error
+	 */
+	public String getProcessingError() {
+	    return processingError_;
+	}
 
-        /**
-         * @param processingError
-         *            the processing error to set
-         */
-        public void setProcessingError(String processingError) {
-            processingError_= processingError;
-        }
+	/**
+	 * @param processingError
+	 *            the processing error to set
+	 */
+	public void setProcessingError(final String processingError) {
+	    processingError_ = processingError;
+	}
 
     }
 
@@ -422,14 +424,14 @@ public class PEPDaemonRequestHandler {
      * 
      * @param messageIssuerId
      *            The entityID of the message issuer
-     * @return
-     *        a decision
+     * @return a decision
      */
-    protected PEPDaemonDecisionRequestContext buildMessageContext(String messageIssuerId) {
-        PEPDaemonDecisionRequestContext messageContext= new PEPDaemonDecisionRequestContext();
-        messageContext.setCommunicationProfileId(AuthzServiceConstants.XACML_SAML_PROFILE_URI);
-        messageContext.setOutboundMessageIssuer(messageIssuerId);
-        messageContext.setSOAPRequestParameters(new HttpSOAPRequestParameters("http://www.oasis-open.org/committees/security"));
-        return messageContext;
+    protected PEPDaemonDecisionRequestContext buildMessageContext(final String messageIssuerId) {
+	PEPDaemonDecisionRequestContext messageContext = new PEPDaemonDecisionRequestContext();
+	messageContext.setCommunicationProfileId(AuthzServiceConstants.XACML_SAML_PROFILE_URI);
+	messageContext.setOutboundMessageIssuer(messageIssuerId);
+	messageContext.setSOAPRequestParameters(
+		new HttpSOAPRequestParameters("http://www.oasis-open.org/committees/security"));
+	return messageContext;
     }
 }

--- a/src/test/java/org/glite/authz/pep/obligation/dfpmap/GridMapDirParallelTest.java
+++ b/src/test/java/org/glite/authz/pep/obligation/dfpmap/GridMapDirParallelTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Members of the EGEE Collaboration. 2006-2010.
+ * See http://www.eu-egee.org/partners/ for details on the copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.glite.authz.pep.obligation.dfpmap;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.apache.commons.io.FileUtils;
+
+import junit.framework.TestCase;
+
+public class GridMapDirParallelTest extends TestCase {
+
+    static int N_THREAD = 10;
+
+    final int N_POOL = 20;
+
+    File gridmapdir = null;
+
+    GridMapDirPoolAccountManager gridmapPool = null;
+    Map<Long, String> resultMap = null;
+
+    final String mAccountPrefix = "tst";
+    final String mSubject = "C=IT, O=IGI, CN=test0";
+
+    private File createTempGridMapDir() throws IOException {
+	File temp = File.createTempFile("test-gridmapdir", ".junit");
+	if (!(temp.delete())) {
+	    throw new IOException("Could not delete temp file: " + temp.getAbsolutePath());
+	}
+
+	if (!(temp.mkdir())) {
+	    throw new IOException("Could not create temp directory: " + temp.getAbsolutePath());
+	}
+
+	temp.deleteOnExit();
+
+	for (int idx = 1; idx <= N_POOL; idx++) {
+	    String lFileName = String.format("%s%02d", mAccountPrefix, idx);
+	    File f = new File(temp, lFileName);
+	    f.createNewFile();
+	    f.deleteOnExit();
+	}
+
+	return temp;
+    }
+
+    private boolean deleteTempGridMapDir(final File path) {
+	boolean lRetVal = false;
+	try {
+	    FileUtils.deleteDirectory(path);
+	    lRetVal = true;
+	} catch (IOException e) {
+	    lRetVal = false;
+	}
+	return lRetVal;
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+	super.setUp();
+	gridmapdir = createTempGridMapDir();
+
+	gridmapPool = new GridMapDirPoolAccountManager(gridmapdir, true);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+	super.tearDown();
+	assertTrue("Failed to delete temp gridmapdir: " + gridmapdir, deleteTempGridMapDir(gridmapdir));
+    }
+
+    public void testParallelMapping() {
+	X500Principal lSubjectDn = new X500Principal(mSubject);
+	CyclicBarrier lBarrier = new CyclicBarrier(N_THREAD, new Runnable() {
+	    public void run() {
+		System.out.println("All thread are arrived at barrier");
+	    }
+	});
+
+	System.out.println("testParallelMapping: START");
+	List<Thread> lThreadList = new ArrayList<Thread>();
+	resultMap = new LinkedHashMap<Long, String>();
+
+	for (int idx = 0; idx < N_THREAD; idx++) {
+	    Thread lThread = new ThreadTester(gridmapPool, lBarrier, mAccountPrefix, lSubjectDn, null, null);
+	    lThreadList.add(lThread);
+	}
+
+	for (Thread lThread : lThreadList) {
+	    lThread.start();
+	}
+
+	try {
+	    for (Thread lThread : lThreadList) {
+		lThread.join();
+	    }
+	} catch (InterruptedException e) {
+	    System.out.println("Thread join interrupted.");
+	}
+
+	String lAccount = null;
+	for (Map.Entry<Long, String> lEntry : resultMap.entrySet()) {
+	    String lRetVal = lEntry.getValue();
+
+	    assertNotNull(lRetVal);
+
+	    if (lAccount == null) {
+		lAccount = lRetVal;
+	    }
+
+	    assertTrue(lRetVal.equals(lAccount));
+	}
+
+	System.out.println("testParallelMapping: END");
+
+    }
+
+    public class ThreadTester extends Thread implements Runnable {
+
+	private GridMapDirPoolAccountManager mGridMapPool;
+	private CyclicBarrier mBarrier;
+	private String mAccountNamePrefix;
+	private X500Principal mSubjectDN;
+	private String mPrimaryGroup;
+	private List<String> mSecondaryGroups;
+
+	public ThreadTester(final GridMapDirPoolAccountManager pGridMapPool, final CyclicBarrier pBarrier,
+		final String pAccountNamePrefix, final X500Principal pSubjectDN, final String pPrimaryGroup,
+		final List<String> pSecondaryGroups) {
+	    this.mGridMapPool = pGridMapPool;
+	    this.mBarrier = pBarrier;
+	    this.mAccountNamePrefix = pAccountNamePrefix;
+	    this.mSubjectDN = pSubjectDN;
+	    this.mPrimaryGroup = pPrimaryGroup;
+	    this.mSecondaryGroups = pSecondaryGroups;
+	}
+
+	@Override
+	public void run() {
+	    String lRetVal = null;
+
+	    try {
+		Long lThreadId = this.getId();
+
+		System.out.println(String.format("Thread [%d] waits on barrier", lThreadId));
+		mBarrier.await();
+		System.out.println(String.format("Thread [%d] has cross the barrier", lThreadId));
+
+		lRetVal = mGridMapPool.mapToAccount(this.mAccountNamePrefix, this.mSubjectDN, this.mPrimaryGroup,
+			this.mSecondaryGroups);
+
+		System.out.println(String.format("Thread [%d] mapped to pool account [%s]", lThreadId, lRetVal));
+		resultMap.put(lThreadId, lRetVal);
+
+	    } catch (Exception e) {
+		e.printStackTrace();
+	    }
+	}
+    }
+
+}

--- a/src/test/java/org/glite/authz/pep/obligation/dfpmap/GridMapDirPoolAccountManagerTest.java
+++ b/src/test/java/org/glite/authz/pep/obligation/dfpmap/GridMapDirPoolAccountManagerTest.java
@@ -24,11 +24,11 @@ import java.util.List;
 
 import javax.security.auth.x500.X500Principal;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.httpclient.URIException;
+import org.apache.commons.io.FileUtils;
 
 import eu.emi.security.authn.x509.impl.OpensslNameUtils;
+import junit.framework.TestCase;
 
 /**
  * JUnit for pool account management and mapping for bug
@@ -36,266 +36,223 @@ import eu.emi.security.authn.x509.impl.OpensslNameUtils;
  */
 public class GridMapDirPoolAccountManagerTest extends TestCase {
 
-    File gridmapdir= null;
+    File gridmapdir = null;
 
-    static int N_POOL= 3;
+    static int N_POOL = 3;
 
-    GridMapDirPoolAccountManager gridmapPool= null;
+    GridMapDirPoolAccountManager gridmapPool = null;
 
-    List<String> prefixes= Arrays.asList("dteam",
-                                         "dteamprod",
-                                         "user1test",
-                                         "user2test",
-                                         "a",
-                                         "aa",
-                                         "a-",
-                                         "a_0a",
-                                         "Z.",
-                                         "lte-dteam");
+    List<String> prefixes = Arrays.asList("dteam", "dteamprod", "user1test", "user2test", "a", "aa", "a-", "a_0a", "Z.",
+	    "lte-dteam");
 
-    List<String> invalids= Arrays.asList("-invalid",
-                                         ".invalid",
-                                         "_invalid",
-                                         "0invalid",
-                                         "0",
-                                         "001",
-                                         "_");
+    List<String> invalids = Arrays.asList("-invalid", ".invalid", "_invalid", "0invalid", "0", "001", "_");
 
     private File createTempGridMapDir() throws IOException {
-        File temp= File.createTempFile("gridmapdir", ".junit");
-        if (!(temp.delete())) {
-            throw new IOException("Could not delete temp file: "
-                    + temp.getAbsolutePath());
-        }
-        if (!(temp.mkdir())) {
-            throw new IOException("Could not create temp directory: "
-                    + temp.getAbsolutePath());
-        }
-        temp.deleteOnExit();
-        // populate with pool accounts
-        for (String prefix : prefixes) {
-            for (int i= 1; i <= N_POOL; i++) {
-                File f= new File(temp, prefix + "0" + i);
-                f.createNewFile();
-                // System.out.println("pool account " + f.getName() +
-                // " created");
-                f.deleteOnExit();
-            }
-        }
-        // create invalid files
-        for (String invalid : invalids) {
-            for (int i= 1; i <= N_POOL; i++) {
-                File f= new File(temp, invalid + "0" + i);
-                f.createNewFile();
-                // System.out.println("invalid " + f.getName() + " created");
-                f.deleteOnExit();
-            }
-        }
-        return temp;
+	File temp = File.createTempFile("gridmapdir", ".junit");
+	if (!(temp.delete())) {
+	    throw new IOException("Could not delete temp file: " + temp.getAbsolutePath());
+	}
+	if (!(temp.mkdir())) {
+	    throw new IOException("Could not create temp directory: " + temp.getAbsolutePath());
+	}
+	temp.deleteOnExit();
+	// populate with pool accounts
+	for (String prefix : prefixes) {
+	    for (int i = 1; i <= N_POOL; i++) {
+		File f = new File(temp, prefix + "0" + i);
+		f.createNewFile();
+		f.deleteOnExit();
+	    }
+	}
+	// create invalid files
+	for (String invalid : invalids) {
+	    for (int i = 1; i <= N_POOL; i++) {
+		File f = new File(temp, invalid + "0" + i);
+		f.createNewFile();
+		f.deleteOnExit();
+	    }
+	}
+	return temp;
     }
 
-    public boolean deleteTempGridMapDir(File path) {
-        if (path.exists()) {
-            File[] files= path.listFiles();
-            for (int i= 0; i < files.length; i++) {
-                if (files[i].isDirectory()) {
-                    deleteTempGridMapDir(files[i]);
-                }
-                else {
-                    files[i].delete();
-                }
-            }
-        }
-        return (path.delete());
+    private boolean deleteTempGridMapDir(final File path) {
+	boolean lRetVal = false;
+	try {
+	    FileUtils.deleteDirectory(path);
+	    lRetVal = true;
+	} catch (IOException e) {
+	    lRetVal = false;
+	}
+	return lRetVal;
     }
 
-    /** {@inheritDoc} */
+    @Override
     protected void setUp() throws Exception {
-        super.setUp();
-        gridmapdir= createTempGridMapDir();
-        
-        // System.out.println("gridmapdir: " + gridmapdir);
-        // for (File file : gridmapdir.listFiles()) {
-        // System.out.println(file);
-        // }
-        
-        gridmapPool= new GridMapDirPoolAccountManager(gridmapdir, true);
+	super.setUp();
+	gridmapdir = createTempGridMapDir();
+
+	gridmapPool = new GridMapDirPoolAccountManager(gridmapdir, true);
     }
 
-    /** {@inheritDoc} */
+    @Override
     protected void tearDown() throws Exception {
-        super.tearDown();
-        // System.out.println("tearDown: delete temp gridmapdir: " +
-        // gridmapdir);
-        assertTrue("Failed to delete temp gridmapdir: " + gridmapdir,
-                   deleteTempGridMapDir(gridmapdir));
+	super.tearDown();
+	assertTrue("Failed to delete temp gridmapdir: " + gridmapdir, deleteTempGridMapDir(gridmapdir));
     }
 
     public void testPoolAccountNamesPrefixed() {
-        System.out.println("------------testPoolAccountNamesPrefixed------------");
-        String prefix= "dteam";
-        List<String> accountNames= gridmapPool.getPoolAccountNames(prefix);
-        System.out.println("accountNames(" + prefix +"): " + accountNames);
-        assertTrue("Empty pool account names for prefix: " + prefix,
-                   accountNames.size() > 0);
-        for (String accountName : accountNames) {
-            System.out.println("checking: " + accountName);
-            assertTrue(accountName + " doesn't match",
-                       accountName.matches(prefix + "\\d+"));
-        }
-        System.out.println("TEST PASSED");
+	System.out.println("------------testPoolAccountNamesPrefixed------------");
+	String prefix = "dteam";
+	List<String> accountNames = gridmapPool.getPoolAccountNames(prefix);
+	System.out.println("accountNames(" + prefix + "): " + accountNames);
+	assertTrue("Empty pool account names for prefix: " + prefix, accountNames.size() > 0);
+	for (String accountName : accountNames) {
+	    System.out.println("checking: " + accountName);
+	    assertTrue(accountName + " doesn't match", accountName.matches(prefix + "\\d+"));
+	}
+	System.out.println("TEST PASSED");
     }
 
     public void testPoolAccountNamesPrefixes() {
-        System.out.println("------------testPoolAccountNamesPrefixes------------");
-        List<String> accountNames= gridmapPool.getPoolAccountNamePrefixes();
-        System.out.println("accountNamePrefixes: " + accountNames);
-        for (String accountName : accountNames) {
-            assertTrue(accountName + " not in prefix list",
-                       prefixes.contains(accountName));
-        }
+	System.out.println("------------testPoolAccountNamesPrefixes------------");
+	List<String> accountNames = gridmapPool.getPoolAccountNamePrefixes();
+	System.out.println("accountNamePrefixes: " + accountNames);
+	for (String accountName : accountNames) {
+	    assertTrue(accountName + " not in prefix list", prefixes.contains(accountName));
+	}
 
-        System.out.println("TEST PASSED");
+	System.out.println("TEST PASSED");
     }
 
     public void testPoolAccountNames() {
-        System.out.println("------------testPoolAccountNames------------");
-        List<String> accountNames= gridmapPool.getPoolAccountNames();
-        System.out.println("poolAccountNames: " + accountNames);
-        assertTrue("Empty pool account names", accountNames.size() > 0);
-        assertEquals(prefixes.size() * N_POOL, accountNames.size());
-        System.out.println("TEST PASSED");
+	System.out.println("------------testPoolAccountNames------------");
+	List<String> accountNames = gridmapPool.getPoolAccountNames();
+	System.out.println("poolAccountNames: " + accountNames);
+	assertTrue("Empty pool account names", accountNames.size() > 0);
+	assertEquals(prefixes.size() * N_POOL, accountNames.size());
+	System.out.println("TEST PASSED");
     }
 
     public void testCreateMapping() {
-        System.out.println("------------testCreateMapping------------");
-        String prefix= "dteam";
-        String identifier= "%2fcn%3djohn%20doe:dteam";
-        String accountName= gridmapPool.createMapping(prefix, identifier);
-        System.out.println("Identifier '" + identifier + "' mapped to: " + accountName);
-        assertTrue(accountName + " doesn't match dteam pool",
-                   accountName.matches(prefix + "\\d+"));
-        System.out.println("TEST PASSED");
+	System.out.println("------------testCreateMapping------------");
+	String prefix = "dteam";
+	String identifier = "%2fcn%3djohn%20doe:dteam";
+	String accountName = gridmapPool.createMapping(prefix, identifier);
+	System.out.println("Identifier '" + identifier + "' mapped to: " + accountName);
+	assertTrue(accountName + " doesn't match dteam pool", accountName.matches(prefix + "\\d+"));
+	System.out.println("TEST PASSED");
     }
 
     public void testMapToAccountPoolDteam() throws Exception {
-        System.out.println("------------testMapToAccountPoolDteam------------");
-        String prefix= "dteam";
-        String subject= "CN=Robin";
-        X500Principal principal= new X500Principal(subject);
-        String accountName= gridmapPool.mapToAccount(prefix,
-                                                     principal,
-                                                     prefix,
-                                                     null);
-        System.out.println("Principal '" + principal + "' with account prefix '" + prefix + "' mapped to: " + accountName);
-        assertTrue(accountName + " doesn't match dteam pool",
-                   accountName.matches(prefix + "\\d+"));
-        System.out.println("TEST PASSED");
+	System.out.println("------------testMapToAccountPoolDteam------------");
+	String prefix = "dteam";
+	String subject = "CN=Robin";
+	X500Principal principal = new X500Principal(subject);
+	String accountName = gridmapPool.mapToAccount(prefix, principal, prefix, null);
+	System.out.println(
+		"Principal '" + principal + "' with account prefix '" + prefix + "' mapped to: " + accountName);
+	assertTrue(accountName + " doesn't match dteam pool", accountName.matches(prefix + "\\d+"));
+	System.out.println("TEST PASSED");
     }
 
     public void testMapToAccountPoolLTEDteam() throws Exception {
-        System.out.println("------------testMapToAccountPoolLTEDteam------------");
-        System.out.println("BUG FIX: https://savannah.cern.ch/bugs/?66574");
-        String prefix= "lte-dteam";
-        List<String> subjects= Arrays.asList("CN=John-John Doe","CN=Batman", "CN=John-John Doe", "CN=Robin", "CN=John-John Doe");
-        for (String subject : subjects) {
-            X500Principal principal= new X500Principal(subject);
-            String accountName= gridmapPool.mapToAccount(prefix,
-                                                         principal,
-                                                         prefix,
-                                                         null);
-            System.out.println("principal '" + principal + "' with account prefix '" + prefix + "' mapped to: " + accountName);
-            assertTrue(accountName + " doesn't match " + prefix + " pool",
-                       accountName.matches(prefix + "\\d+"));
-        }
-        System.out.println("TEST PASSED");
+	System.out.println("------------testMapToAccountPoolLTEDteam------------");
+	System.out.println("BUG FIX: https://savannah.cern.ch/bugs/?66574");
+	String prefix = "lte-dteam";
+	List<String> subjects = Arrays.asList("CN=John-John Doe", "CN=Batman", "CN=John-John Doe", "CN=Robin",
+		"CN=John-John Doe");
+	for (String subject : subjects) {
+	    X500Principal principal = new X500Principal(subject);
+	    String accountName = gridmapPool.mapToAccount(prefix, principal, prefix, null);
+	    System.out.println(
+		    "principal '" + principal + "' with account prefix '" + prefix + "' mapped to: " + accountName);
+	    assertTrue(accountName + " doesn't match " + prefix + " pool", accountName.matches(prefix + "\\d+"));
+	}
+	System.out.println("TEST PASSED");
     }
-    
-    public void testSubjectIdentifierFileTimestampUpdate() throws Exception {
-        System.out.println("------------testSubjectIdentifierFileTimestampUpdate------------");
-        System.out.println("BUG FIX: https://savannah.cern.ch/bugs/index.php?83281");
-        System.out.println("BUG FIX: https://savannah.cern.ch/bugs/index.php?84846");
-        String prefix= "dteam";
-        List<String> subjects= Arrays.asList("CN=Batman","CN=Batman","CN=Batman","CN=Robin","CN=Robin","CN=Robin","CN=John-John Doe", "CN=John-John Doe", "CN=John-John Doe","CN=John-John Doe","CN=John-John Doe");
-        long lastmodified= System.currentTimeMillis();
-        for (String subject : subjects) {
-            // touch granularity in 1 sec!!!
-            Thread.sleep(1000);
-            X500Principal principal= new X500Principal(subject);
-            String accountName= gridmapPool.mapToAccount(prefix,
-                                                         principal,
-                                                         prefix,
-                                                         null);
-            System.out.println("Principal '" + principal + "' with account prefix '" + prefix + "' mapped to: " + accountName);
-            assertTrue(accountName + " doesn't match " + prefix + " pool",
-                       accountName.matches(prefix + "\\d+"));
-            
-            String subjectIdentifier= gridmapPool.buildSubjectIdentifier(principal, prefix, null);
-            String subjectIdentifierFilePath= gridmapPool.buildSubjectIdentifierFilePath(subjectIdentifier);
-            File subjectIdentifierFile= new File(subjectIdentifierFilePath);
-            System.out.println("Subject identifier file: " + subjectIdentifierFile);
-            System.out.println("Lastmodified: " + lastmodified + " < " + subjectIdentifierFile.lastModified());
-            assertTrue("Timestamp not updated", lastmodified < subjectIdentifierFile.lastModified());
-            lastmodified= subjectIdentifierFile.lastModified();
-        }
 
-        System.out.println("TEST PASSED");
-        
+    public void testSubjectIdentifierFileTimestampUpdate() throws Exception {
+	System.out.println("------------testSubjectIdentifierFileTimestampUpdate------------");
+	System.out.println("BUG FIX: https://savannah.cern.ch/bugs/index.php?83281");
+	System.out.println("BUG FIX: https://savannah.cern.ch/bugs/index.php?84846");
+	String prefix = "dteam";
+	List<String> subjects = Arrays.asList("CN=Batman", "CN=Batman", "CN=Batman", "CN=Robin", "CN=Robin", "CN=Robin",
+		"CN=John-John Doe", "CN=John-John Doe", "CN=John-John Doe", "CN=John-John Doe", "CN=John-John Doe");
+	long lastmodified = System.currentTimeMillis();
+	for (String subject : subjects) {
+	    // touch granularity in 1 sec!!!
+	    Thread.sleep(1000);
+	    X500Principal principal = new X500Principal(subject);
+	    String accountName = gridmapPool.mapToAccount(prefix, principal, prefix, null);
+	    System.out.println(
+		    "Principal '" + principal + "' with account prefix '" + prefix + "' mapped to: " + accountName);
+	    assertTrue(accountName + " doesn't match " + prefix + " pool", accountName.matches(prefix + "\\d+"));
+
+	    String subjectIdentifier = gridmapPool.buildSubjectIdentifier(principal, prefix, null);
+	    String subjectIdentifierFilePath = gridmapPool.buildSubjectIdentifierFilePath(subjectIdentifier);
+	    File subjectIdentifierFile = new File(subjectIdentifierFilePath);
+	    System.out.println("Subject identifier file: " + subjectIdentifierFile);
+	    System.out.println("Lastmodified: " + lastmodified + " < " + subjectIdentifierFile.lastModified());
+	    assertTrue("Timestamp not updated", lastmodified < subjectIdentifierFile.lastModified());
+	    lastmodified = subjectIdentifierFile.lastModified();
+	}
+
+	System.out.println("TEST PASSED");
+
     }
-    
+
     public void testSubjectIdentifierFilenameWithSecGroups() throws URIException {
-        System.out.println("------------testSubjectIdentifierFilenameWithSecGroups------------");
-        System.out.println("BUG FIX: https://savannah.cern.ch/bugs/?83317");
-        String group= "lte-dteam";
-        List<String> groups= Arrays.asList("cms","LTE","DTEAM");
-        X500Principal principal= new X500Principal("CN=John-John Doe,DC=Test,DC=users");
-        System.out.println("Principal: " + principal);
-        System.out.println("Group: " + group);
-        System.out.println("Groups: " + groups);
-        String leaseFilename= gridmapPool.buildSubjectIdentifier(principal, group, groups);
-        System.out.println("Lease filename: " + leaseFilename);
-        assertTrue("Wrong lease filename generated",leaseFilename.contains("lte-dteam"));
-        assertTrue("Wrong lease filename generated",leaseFilename.contains("cms"));
-        assertTrue("Wrong lease filename generated",leaseFilename.contains("LTE"));
-        assertTrue("Wrong lease filename generated",leaseFilename.contains("DTEAM"));
-        System.out.println("TEST PASSED");
+	System.out.println("------------testSubjectIdentifierFilenameWithSecGroups------------");
+	System.out.println("BUG FIX: https://savannah.cern.ch/bugs/?83317");
+	String group = "lte-dteam";
+	List<String> groups = Arrays.asList("cms", "LTE", "DTEAM");
+	X500Principal principal = new X500Principal("CN=John-John Doe,DC=Test,DC=users");
+	System.out.println("Principal: " + principal);
+	System.out.println("Group: " + group);
+	System.out.println("Groups: " + groups);
+	String leaseFilename = gridmapPool.buildSubjectIdentifier(principal, group, groups);
+	System.out.println("Lease filename: " + leaseFilename);
+	assertTrue("Wrong lease filename generated", leaseFilename.contains("lte-dteam"));
+	assertTrue("Wrong lease filename generated", leaseFilename.contains("cms"));
+	assertTrue("Wrong lease filename generated", leaseFilename.contains("LTE"));
+	assertTrue("Wrong lease filename generated", leaseFilename.contains("DTEAM"));
+	System.out.println("TEST PASSED");
     }
 
     public void testSubjectIdentifierFilenameWithoutSecGroups() throws URIException {
-        System.out.println("------------testSubjectIdentifierFilenameWithoutSecGroups------------");
-        System.out.println("BUG FIX: https://savannah.cern.ch/bugs/?83317");
-        String group= "lte-dteam";
-        List<String> groups= Arrays.asList("cms","LTE","dteam");
-        X500Principal principal= new X500Principal("CN=John-John Doe,DC=Test,DC=users");
-        System.out.println("Principal: " + principal);
-        System.out.println("Group: " + group);
-        System.out.println("Groups: " + groups);
-        gridmapPool.setUseSecondaryGroupNamesForMapping(false);
-        String leaseFilename= gridmapPool.buildSubjectIdentifier(principal, group, groups);
-        System.out.println("Lease filename: " + leaseFilename);
-        assertTrue("Wrong lease filename generated",leaseFilename.contains("lte-dteam"));
-        assertFalse("Wrong lease filename generated",leaseFilename.contains("cms"));
-        assertFalse("Wrong lease filename generated",leaseFilename.contains("LTE"));
-        assertFalse("Wrong lease filename generated",leaseFilename.contains("DTEAM"));
-        System.out.println("TEST PASSED");
+	System.out.println("------------testSubjectIdentifierFilenameWithoutSecGroups------------");
+	System.out.println("BUG FIX: https://savannah.cern.ch/bugs/?83317");
+	String group = "lte-dteam";
+	List<String> groups = Arrays.asList("cms", "LTE", "dteam");
+	X500Principal principal = new X500Principal("CN=John-John Doe,DC=Test,DC=users");
+	System.out.println("Principal: " + principal);
+	System.out.println("Group: " + group);
+	System.out.println("Groups: " + groups);
+	gridmapPool.setUseSecondaryGroupNamesForMapping(false);
+	String leaseFilename = gridmapPool.buildSubjectIdentifier(principal, group, groups);
+	System.out.println("Lease filename: " + leaseFilename);
+	assertTrue("Wrong lease filename generated", leaseFilename.contains("lte-dteam"));
+	assertFalse("Wrong lease filename generated", leaseFilename.contains("cms"));
+	assertFalse("Wrong lease filename generated", leaseFilename.contains("LTE"));
+	assertFalse("Wrong lease filename generated", leaseFilename.contains("DTEAM"));
+	System.out.println("TEST PASSED");
     }
 
-    
     public void testSubjectIdentifierEncoding() throws URIException {
-        System.out.println("------------testSubjectIdentifierEncoding------------");
-        System.out.println("BUG FIX: https://savannah.cern.ch/bugs/index.php?83419");
-        X500Principal principal= new X500Principal("CN=John-John Doe,DC=Test,DC=users");
-        System.out.println("Principal: " + principal);
-        String rfc2253Subject= principal.getName();
-        String openSSLSubject= OpensslNameUtils.convertFromRfc2253(rfc2253Subject, false);
-        System.out.println("Subject: " + openSSLSubject);
-        String encodedSubject= gridmapPool.encodeSubjectIdentifier(openSSLSubject);
-        System.out.println("Encoded subject: " + encodedSubject);
-        assertFalse("Subject not correctly encoded",encodedSubject.contains("-"));
-        assertFalse("Subject not correctly encoded",encodedSubject.contains("/"));
-        assertFalse("Subject not correctly encoded",encodedSubject.contains("="));
-        assertFalse("Subject not correctly encoded",encodedSubject.contains(" "));
-        System.out.println("TEST PASSED");
+	System.out.println("------------testSubjectIdentifierEncoding------------");
+	System.out.println("BUG FIX: https://savannah.cern.ch/bugs/index.php?83419");
+	X500Principal principal = new X500Principal("CN=John-John Doe,DC=Test,DC=users");
+	System.out.println("Principal: " + principal);
+	String rfc2253Subject = principal.getName();
+	String openSSLSubject = OpensslNameUtils.convertFromRfc2253(rfc2253Subject, false);
+	System.out.println("Subject: " + openSSLSubject);
+	String encodedSubject = gridmapPool.encodeSubjectIdentifier(openSSLSubject);
+	System.out.println("Encoded subject: " + encodedSubject);
+	assertFalse("Subject not correctly encoded", encodedSubject.contains("-"));
+	assertFalse("Subject not correctly encoded", encodedSubject.contains("/"));
+	assertFalse("Subject not correctly encoded", encodedSubject.contains("="));
+	assertFalse("Subject not correctly encoded", encodedSubject.contains(" "));
+	System.out.println("TEST PASSED");
     }
-    
+
 }


### PR DESCRIPTION
Fix for: https://github.com/argus-authz/argus-pep-server/issues/3.

Resolved the syncronization issue of concurrent requests protecting the critical section with:
- synchronized method createMapping();
- lock file.

Synchronized method ensures that threads running on the same pep-server enter the critical section one at a time; lock file ensure mutual exclusion between thread of different pep-server.

Now, the workflow basically is:
1. If the subject identifier file doesn't exist:
   - call createMapping();
   - in this function, try to get the lock;
   - if lock file already exist, the thread wait, because another thread is in the critical section;
   - got the lock, recheck subject identifier file: if already exists (another thread has created the mapping while this thread is waiting), go ahead, otherwise, create the mapping;
   - if hardlink count is correct, release the lock and return the account name;
2. call getExistingMapping()
