### PR TITLE
Change default value for authentication profile policy file

### DIFF
--- a/src/main/config/pepd.ini
+++ b/src/main/config/pepd.ini
@@ -70,7 +70,7 @@ acceptedProfileIDs = http://dci-sec.org/xacml/profile/common-authz/1.1
 
 [AUTHN_PROFILE_PIP]
 parserClass = org.glite.authz.pep.pip.provider.authnprofilespip.AuthenticationProfilePIPConfigurationParser
-authenticationProfilePolicyFile = /etc/grid-security/vo-ca-ap-file
+authenticationProfilePolicyFile = /etc/argus/pepd/vo-ca-ap-file
 trustAnchors.directory = /etc/grid-security/certificates
 trustAnchors.policyFilePattern = policy-*.info
 trustAnchors.refreshIntervalInSecs = 14400

--- a/src/main/config/vo-ca-ap-file
+++ b/src/main/config/vo-ca-ap-file
@@ -1,0 +1,7 @@
+# Any VO for classic, mics and slcs
+/*       file:policy-igtf-classic.info, file:policy-igtf-mics.info,\
+         file:policy-igtf-slcs.info
+
+# Any non-VOMS proxy also only for classic, mics and slcs
+"-"      file:policy-igtf-classic.info, file:policy-igtf-mics.info,\
+         file:policy-igtf-slcs.info

--- a/src/main/java/org/glite/authz/pep/pip/provider/authnprofilespip/DefaultAuthenticationProfilePDP.java
+++ b/src/main/java/org/glite/authz/pep/pip/provider/authnprofilespip/DefaultAuthenticationProfilePDP.java
@@ -33,75 +33,89 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An implementation for {@link AuthenticationProfilePDP}. Decisions are rendered taking into
- * account the authentication profiles obtained by the {@link AuthenticationProfileRepository} and
- * the {@link AuthenticationProfilePolicySet} used to build a
+ * An implementation for {@link AuthenticationProfilePDP}. Decisions are
+ * rendered taking into account the authentication profiles obtained by the
+ * {@link AuthenticationProfileRepository} and the
+ * {@link AuthenticationProfilePolicySet} used to build a
  * {@link DefaultAuthenticationProfilePDP}.
  * 
  * A {@link Builder} class is provided to simplify creating this PDP.
  * 
  */
-public class DefaultAuthenticationProfilePDP implements AuthenticationProfilePDP {
-  
-  public static final Logger LOG = LoggerFactory.getLogger(DefaultAuthenticationProfilePDP.class);
+public class DefaultAuthenticationProfilePDP
+  implements AuthenticationProfilePDP {
+
+  public static final Logger LOG = LoggerFactory
+    .getLogger(DefaultAuthenticationProfilePDP.class);
 
   protected final AuthenticationProfileRepository profileRepository;
   protected final AuthenticationProfilePolicySetRepository policyRepository;
 
   protected final long refreshIntervalInSecs;
-  
+
   ScheduledExecutorService repositoryRefreshExecutorService;
 
-  public DefaultAuthenticationProfilePDP(AuthenticationProfileRepository profileRepo,
-      AuthenticationProfilePolicySetRepository policyRepo, long refreshIntervalInSecs) throws IOException {
+  public DefaultAuthenticationProfilePDP(
+    AuthenticationProfileRepository profileRepo,
+    AuthenticationProfilePolicySetRepository policyRepo,
+    long refreshIntervalInSecs) throws IOException {
+
     this.profileRepository = profileRepo;
     this.policyRepository = policyRepo;
     this.refreshIntervalInSecs = refreshIntervalInSecs;
   }
-  
-  public DefaultAuthenticationProfilePDP(AuthenticationProfileRepository profileRepo,
-      AuthenticationProfilePolicySetRepository policyRepo) throws IOException {
+
+  public DefaultAuthenticationProfilePDP(
+    AuthenticationProfileRepository profileRepo,
+    AuthenticationProfilePolicySetRepository policyRepo) throws IOException {
+
     this(profileRepo, policyRepo, -1);
   }
 
   protected void boostrapRepositoryRefresh() {
-    
+
     if (refreshIntervalInSecs <= 0) {
       LOG.info("Repositories will not be refreshed: refreshInterval <= 0");
       return;
     }
 
     repositoryRefreshExecutorService = Executors
-      .newSingleThreadScheduledExecutor(new AuthenticationProfileRefresherThreadFactory());
+      .newSingleThreadScheduledExecutor(
+        new AuthenticationProfileRefresherThreadFactory());
 
     repositoryRefreshExecutorService.scheduleAtFixedRate(
-        new RefreshRepositoryTask(profileRepository), 0, refreshIntervalInSecs, TimeUnit.SECONDS);
-    
+      new RefreshRepositoryTask(profileRepository), 0, refreshIntervalInSecs,
+      TimeUnit.SECONDS);
+
     repositoryRefreshExecutorService.scheduleAtFixedRate(
-        new RefreshRepositoryTask(policyRepository), 0, refreshIntervalInSecs, TimeUnit.SECONDS);
+      new RefreshRepositoryTask(policyRepository), 0, refreshIntervalInSecs,
+      TimeUnit.SECONDS);
   }
 
   private Set<AuthenticationProfile> lookupProfiles(String caSubject) {
+
     requireNonNull(caSubject, "Please provide a non-null caSubject argument");
 
-    Set<AuthenticationProfile> profiles = profileRepository.findProfilesForSubject(caSubject);
+    Set<AuthenticationProfile> profiles = profileRepository
+      .findProfilesForSubject(caSubject);
 
     if (profiles.isEmpty()) {
       throw new AuthenticationProfileError(
-          "No authentication profile found for CA subject: " + caSubject);
+        "No authentication profile found for CA subject: " + caSubject);
     }
 
     return profiles;
   }
 
-  private Decision policyDecision(AuthenticationProfilePolicy policy, String caSubject,
-      Set<AuthenticationProfile> profiles) {
+  private Decision policyDecision(AuthenticationProfilePolicy policy,
+    String caSubject, Set<AuthenticationProfile> profiles) {
 
     requireNonNull(policy);
     requireNonNull(caSubject);
     requireNonNull(profiles);
 
-    Optional<AuthenticationProfile> allowedProfile = policy.supportsAtLeastOneProfile(profiles);
+    Optional<AuthenticationProfile> allowedProfile = policy
+      .supportsAtLeastOneProfile(profiles);
 
     if (allowedProfile.isPresent()) {
       return allow(caSubject, allowedProfile.get());
@@ -116,8 +130,10 @@ public class DefaultAuthenticationProfilePDP implements AuthenticationProfilePDP
     requireNonNull(voName, "Please provide a non-null vo name");
     Set<AuthenticationProfile> principalProfiles = lookupProfiles(caSubject);
 
-    AuthenticationProfilePolicy voPolicy =
-        policyRepository.getAuthenticationProfilePolicySet().getVoProfilePolicies().get(voName);
+    AuthenticationProfilePolicy voPolicy = policyRepository
+      .getAuthenticationProfilePolicySet()
+      .getVoProfilePolicies()
+      .get(voName);
 
     Decision decision = Decision.deny(caSubject);
 
@@ -130,9 +146,13 @@ public class DefaultAuthenticationProfilePDP implements AuthenticationProfilePDP
       }
     }
 
-    if (policyRepository.getAuthenticationProfilePolicySet().getAnyVoProfilePolicy().isPresent()) {
-      AuthenticationProfilePolicy anyVoPolicy =
-          policyRepository.getAuthenticationProfilePolicySet().getAnyVoProfilePolicy().get();
+    if (policyRepository.getAuthenticationProfilePolicySet()
+      .getAnyVoProfilePolicy()
+      .isPresent()) {
+      AuthenticationProfilePolicy anyVoPolicy = policyRepository
+        .getAuthenticationProfilePolicySet()
+        .getAnyVoProfilePolicy()
+        .get();
       decision = policyDecision(anyVoPolicy, caSubject, principalProfiles);
     }
 
@@ -148,10 +168,12 @@ public class DefaultAuthenticationProfilePDP implements AuthenticationProfilePDP
       .getAnyCertificateProfilePolicy()
       .isPresent()) {
       AuthenticationProfilePolicy anyCertPolicy = policyRepository
-        .getAuthenticationProfilePolicySet().getAnyCertificateProfilePolicy().get();
+        .getAuthenticationProfilePolicySet()
+        .getAnyCertificateProfilePolicy()
+        .get();
 
-      Optional<AuthenticationProfile> allowedProfile =
-          anyCertPolicy.supportsAtLeastOneProfile(principalProfiles);
+      Optional<AuthenticationProfile> allowedProfile = anyCertPolicy
+        .supportsAtLeastOneProfile(principalProfiles);
 
       if (allowedProfile.isPresent()) {
         return allow(caSubject, allowedProfile.get());
@@ -161,7 +183,6 @@ public class DefaultAuthenticationProfilePDP implements AuthenticationProfilePDP
     return deny(caSubject);
   }
 
-
   /**
    * 
    * A builder for {@link DefaultAuthenticationProfilePDP}.
@@ -169,86 +190,101 @@ public class DefaultAuthenticationProfilePDP implements AuthenticationProfilePDP
    */
   public static class Builder {
 
-    private String authenticationPolicyFile = "/etc/grid-security/vo-ca-ap-file";
+    private String authenticationPolicyFile = "/etc/argus/pepd/vo-ca-ap-file";
     private String trustAnchorsDir = "/etc/grid-security/certificates";
     private String policyFilePattern = "policy-*.info";
     private int refreshIntervalInSecs = -1;
 
     public Builder authenticationPolicyFile(String f) {
+
       this.authenticationPolicyFile = f;
       return this;
     }
 
     public Builder trustAnchorsDir(String dir) {
+
       this.trustAnchorsDir = dir;
       return this;
     }
 
     public Builder policyFilePattern(String pfp) {
+
       this.policyFilePattern = pfp;
       return this;
     }
 
     public Builder refreshIntervalInSecs(int refreshInterval) {
+
       this.refreshIntervalInSecs = refreshInterval;
       return this;
     }
 
     public DefaultAuthenticationProfilePDP build() throws IOException {
 
-      AuthenticationProfileRepository profileRepo =
-          new TrustAnchorsDirectoryAuthenticationProfileRepository(trustAnchorsDir,
-              policyFilePattern);
+      AuthenticationProfileRepository profileRepo = new TrustAnchorsDirectoryAuthenticationProfileRepository(
+        trustAnchorsDir, policyFilePattern);
 
-      AuthenticationProfilePolicySetBuilder parser =
-          new VoCaApInfoFileParser(authenticationPolicyFile, profileRepo);
+      AuthenticationProfilePolicySetBuilder parser = new VoCaApInfoFileParser(
+        authenticationPolicyFile, profileRepo);
 
-      AuthenticationProfilePolicySetRepository policySetRepo =
-          new DefaultAuthenticationProfilePolicySetRepository(parser);
+      AuthenticationProfilePolicySetRepository policySetRepo = new DefaultAuthenticationProfilePolicySetRepository(
+        parser);
 
-      return new DefaultAuthenticationProfilePDP(profileRepo, 
-          policySetRepo, refreshIntervalInSecs); 
+      return new DefaultAuthenticationProfilePDP(profileRepo, policySetRepo,
+        refreshIntervalInSecs);
     }
   }
 
   static class RefreshRepositoryTask implements Runnable {
-    private static final Logger LOG = LoggerFactory.getLogger(RefreshRepositoryTask.class);
+
+    private static final Logger LOG = LoggerFactory
+      .getLogger(RefreshRepositoryTask.class);
 
     final ReloadingRepository repository;
 
     public RefreshRepositoryTask(ReloadingRepository repo) {
+
       this.repository = repo;
     }
 
     @Override
     public void run() {
+
       try {
         repository.reloadRepositoryContents();
       } catch (Throwable e) {
         LOG.error("Error reloading repository {} contents: {}",
-            repository.getClass().getSimpleName(), e.getMessage(), e);
+          repository.getClass()
+            .getSimpleName(),
+          e.getMessage(), e);
       }
     }
 
   }
-  static class AuthenticationProfileRefresherThreadFactory implements ThreadFactory {
+
+  static class AuthenticationProfileRefresherThreadFactory
+    implements ThreadFactory {
 
     public static final String THREAD_NAME = "authn-profile-refresher";
 
     @Override
     public Thread newThread(Runnable r) {
+
       return new Thread(r, THREAD_NAME);
     }
   }
+
   @Override
   public void start() {
+
     boostrapRepositoryRefresh();
   }
 
   @Override
   public void stop() {
-   if (repositoryRefreshExecutorService != null){
-     repositoryRefreshExecutorService.shutdown();
-   }
+
+    if (repositoryRefreshExecutorService != null) {
+      repositoryRefreshExecutorService.shutdown();
+    }
   }
 }


### PR DESCRIPTION
This PR changes the default value for authentication profile policy file.
The main fixes are:
 - introduction of a new file in PEP server configuration directory;
 - change the default value of the `authenticationProfilePolicyFile` property from /`etc/grid-security/vo-ca-ap-file` to this new file;
 - change the INI parser to fallback to this new file if the authentication profile file specified in the configuration is not readable.
